### PR TITLE
depend on isl012 instead of isl since the latest isl is not compatible

### DIFF
--- a/avr-gcc48.rb
+++ b/avr-gcc48.rb
@@ -18,7 +18,7 @@ class AvrGcc48 < Formula
     depends_on 'libmpc'
     depends_on 'mpfr'
     depends_on 'cloog'
-    depends_on 'isl'
+    depends_on 'isl012'
 
     depends_on 'avr-binutils'
 
@@ -50,7 +50,7 @@ class AvrGcc48 < Formula
             "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
             "--with-mpc=#{Formula["libmpc"].opt_prefix}",
             "--with-cloog=#{Formula["cloog"].opt_prefix}",
-            "--with-isl=#{Formula["isl"].opt_prefix}",
+            "--with-isl=#{Formula["isl012"].opt_prefix}",
             "--with-system-zlib"
         ]
 


### PR DESCRIPTION
avr-gcc48 requires isl <  0.13
