### PR TITLE
Remove outdated (cardse.net) mirror and use the working one.

### DIFF
--- a/avr-gcc.rb
+++ b/avr-gcc.rb
@@ -6,8 +6,8 @@ require 'formula'
 class AvrGcc < Formula
 
     homepage 'http://www.gnu.org/software/gcc/gcc.html'
-    url 'http://gnu.cardse.net/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2'
-    mirror 'ftp://gcc.gnu.org/pub/gcc/releases/gcc-4.9.2/gcc-4.9.2.tar.bz2'
+    url 'ftp://gcc.gnu.org/pub/gcc/releases/gcc-4.9.2/gcc-4.9.2.tar.bz2'
+    mirror 'http://ftpmirror.gnu.org/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2'
     sha256 '2020c98295856aa13fda0f2f3a4794490757fc24bcca918d52cc8b4917b972dd'
 
     depends_on 'gmp'


### PR DESCRIPTION
gnu.cardse.net mirror doesn't host the necessary file under that link. I removed it and successfully tried the second one (from gnu.org).
