### PR TITLE
Remove cloog and ISL dependency from avr-gcc48

### DIFF
--- a/avr-gcc48.rb
+++ b/avr-gcc48.rb
@@ -15,7 +15,6 @@ class AvrGcc48 < Formula
     depends_on 'gmp'
     depends_on 'libmpc'
     depends_on 'mpfr'
-    depends_on 'cloog'
 
     depends_on 'avr-binutils'
 
@@ -46,7 +45,6 @@ class AvrGcc48 < Formula
             "--with-gmp=#{Formula["gmp"].opt_prefix}",
             "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
             "--with-mpc=#{Formula["libmpc"].opt_prefix}",
-            "--with-cloog=#{Formula["cloog"].opt_prefix}",
             "--with-system-zlib"
         ]
 

--- a/avr-gcc48.rb
+++ b/avr-gcc48.rb
@@ -16,7 +16,6 @@ class AvrGcc48 < Formula
     depends_on 'libmpc'
     depends_on 'mpfr'
     depends_on 'cloog'
-    depends_on 'isl'
 
     depends_on 'avr-binutils'
 
@@ -48,7 +47,6 @@ class AvrGcc48 < Formula
             "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
             "--with-mpc=#{Formula["libmpc"].opt_prefix}",
             "--with-cloog=#{Formula["cloog"].opt_prefix}",
-            "--with-isl=#{Formula["isl"].opt_prefix}",
             "--with-system-zlib"
         ]
 


### PR DESCRIPTION
This PR fixes #20.
Because Homebrew mainline isl version is 0.15, but gcc-48 requires 0.10 or 0.11 or 0.12 or 0.14.
We should use one of adopted versions. So, I use homebrew-versions' isl012.
