### PR TITLE
avr-gdb: Specify depends_on explicitly

### DIFF
--- a/avr-gdb.rb
+++ b/avr-gdb.rb
@@ -8,6 +8,11 @@ class AvrGdb < Formula
     sha1 '67cfbc6efcff674aaac3af83d281cf9df0839ff9'
 
     depends_on 'avr-binutils'
+    depends_on 'gmp'
+    depends_on 'mpfr'
+    depends_on 'libmpc'
+    depends_on 'cloog'
+    depends_on 'isl012'
 
     def install
         args = [
@@ -23,7 +28,7 @@ class AvrGdb < Formula
             "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
             "--with-mpc=#{Formula["libmpc"].opt_prefix}",
             "--with-cloog=#{Formula["cloog"].opt_prefix}",
-            "--with-isl=#{Formula["isl"].opt_prefix}"
+            "--with-isl=#{Formula["isl012"].opt_prefix}"
         ]
 
         mkdir 'build' do

--- a/avr-gdb.rb
+++ b/avr-gdb.rb
@@ -11,8 +11,6 @@ class AvrGdb < Formula
     depends_on 'gmp'
     depends_on 'mpfr'
     depends_on 'libmpc'
-    depends_on 'cloog'
-    depends_on 'isl012'
 
     def install
         args = [
@@ -26,9 +24,7 @@ class AvrGdb < Formula
 
             "--with-gmp=#{Formula["gmp"].opt_prefix}",
             "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
-            "--with-mpc=#{Formula["libmpc"].opt_prefix}",
-            "--with-cloog=#{Formula["cloog"].opt_prefix}",
-            "--with-isl=#{Formula["isl012"].opt_prefix}"
+            "--with-mpc=#{Formula["libmpc"].opt_prefix}"
         ]
 
         mkdir 'build' do


### PR DESCRIPTION
Fixes: #18 
Because Homebrew mainline isl version is now 0.15 and `"--with-isl=#{Formula["isl"].opt_prefix}"` is pointed to Homebrew mainline version of isl opt directory.
This PR adds explicit `depends_on` and fixes wrong `--with-isl` configure option.
`"--with-isl=#{Formula["isl"].opt_prefix}"` should replace with `"--with-isl=#{Formula["isl012"].opt_prefix}"`.

@jpommerening Could you confirm this PR?
