### PR TITLE
The patch previously required for simavr is obsolete

### DIFF
--- a/simavr.rb
+++ b/simavr.rb
@@ -6,13 +6,6 @@ class Simavr < Formula
   depends_on "avr-libc"
   depends_on "libelf"
 
-  head do
-    patch :p1 do
-      url "https://patch-diff.githubusercontent.com/raw/buserror/simavr/pull/149.diff"
-      sha256 "2899af128549706da8b964fc3838f9edb729ad37557143a25ec1bdd6da2985b6"
-    end
-  end
-
   def install
     system "make", "install", "DESTDIR=#{prefix}", "HOMEBREW_PREFIX=#{HOMEBREW_PREFIX}", "RELEASE=1"
     prefix.install "examples"


### PR DESCRIPTION
This patch has already been applied to the head of simavr, so it just generates a meaningless conflict
