### PR TITLE
formulae: style tweaks

### DIFF
--- a/avr-binutils.rb
+++ b/avr-binutils.rb
@@ -5,13 +5,13 @@ class AvrBinutils < Formula
     homepage 'http://www.gnu.org/software/binutils/binutils.html'
     url 'http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz'
     mirror 'http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz'
-    sha1 'f10c64e92d9c72ee428df3feaf349c4ecb2493bd'
+    sha256 'd955d7d6925bf44267b42e8f9df662a9e2f812f3a5cdc88a39f4cf5e72aeb8a1'
 
     # Support for -C in avr-size. See issue
     # https://github.com/larsimmisch/homebrew-avr/issues/9
     patch :p0 do
         url 'https://gist.github.com/larsimmisch/4190960/raw/b36f3d6d086980006f097ae0acc80b3ada7bb7b1/avr-binutils-size.patch'
-        sha1 'b6d1ff7084b1f0a3fd2dee5383019ffb202e6c9a'
+        sha256 '1776fa53ec8c8cc6031c205be0ca358db32fccef7831d29d17b3435309ef7a1c'
     end
 
     def install

--- a/avr-binutils.rb
+++ b/avr-binutils.rb
@@ -1,38 +1,35 @@
-require 'formula'
-
 class AvrBinutils < Formula
+  homepage "https://www.gnu.org/software/binutils/binutils.html"
+  url "https://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz"
+  mirror "https://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz"
+  sha256 "d955d7d6925bf44267b42e8f9df662a9e2f812f3a5cdc88a39f4cf5e72aeb8a1"
 
-    homepage 'http://www.gnu.org/software/binutils/binutils.html'
-    url 'http://ftpmirror.gnu.org/binutils/binutils-2.25.tar.gz'
-    mirror 'http://ftp.gnu.org/gnu/binutils/binutils-2.25.tar.gz'
-    sha256 'd955d7d6925bf44267b42e8f9df662a9e2f812f3a5cdc88a39f4cf5e72aeb8a1'
+  # Support for -C in avr-size. See issue
+  # https://github.com/larsimmisch/homebrew-avr/issues/9
+  patch :p0 do
+    url "https://gist.github.com/larsimmisch/4190960/raw/b36f3d6d086980006f097ae0acc80b3ada7bb7b1/avr-binutils-size.patch"
+    sha256 "1776fa53ec8c8cc6031c205be0ca358db32fccef7831d29d17b3435309ef7a1c"
+  end
 
-    # Support for -C in avr-size. See issue
-    # https://github.com/larsimmisch/homebrew-avr/issues/9
-    patch :p0 do
-        url 'https://gist.github.com/larsimmisch/4190960/raw/b36f3d6d086980006f097ae0acc80b3ada7bb7b1/avr-binutils-size.patch'
-        sha256 '1776fa53ec8c8cc6031c205be0ca358db32fccef7831d29d17b3435309ef7a1c'
+  def install
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --target=avr
+      --prefix=#{prefix}
+      --infodir=#{info}
+      --mandir=#{man}
+      --disable-werror
+      --disable-nls
+    ]
+
+    mkdir "build" do
+      system "../configure", *args
+
+      system "make"
+      system "make", "install"
     end
 
-    def install
-        args = [
-            "--disable-debug",
-            "--disable-dependency-tracking",
-            "--target=avr",
-            "--prefix=#{prefix}",
-            "--infodir=#{info}",
-            "--mandir=#{man}",
-            "--disable-werror",
-            "--disable-nls"
-        ]
-
-        mkdir 'build' do
-            system "../configure", *args
-
-            system "make"
-            system "make install"
-        end
-
-        info.rmtree # info files conflict with native binutils
-    end
+    info.rmtree # info files conflict with native binutils
+  end
 end

--- a/avr-gcc.rb
+++ b/avr-gcc.rb
@@ -1,62 +1,60 @@
-require 'formula'
-
 # print avr-gcc's builtin include paths
 # `avr-gcc -print-prog-name=cc1plus` -v
 
 class AvrGcc < Formula
+  homepage "https://www.gnu.org/software/gcc/gcc.html"
+  url "ftp://gcc.gnu.org/pub/gcc/releases/gcc-4.9.3/gcc-4.9.3.tar.bz2"
+  mirror "https://ftpmirror.gnu.org/gcc/gcc-4.9.3/gcc-4.9.3.tar.bz2"
+  sha256 "2332b2a5a321b57508b9031354a8503af6fdfb868b8c1748d33028d100a8b67e"
 
-    homepage 'http://www.gnu.org/software/gcc/gcc.html'
-    url 'ftp://gcc.gnu.org/pub/gcc/releases/gcc-4.9.3/gcc-4.9.3.tar.bz2'
-    mirror 'http://ftpmirror.gnu.org/gcc/gcc-4.9.3/gcc-4.9.3.tar.bz2'
-    sha256 '2332b2a5a321b57508b9031354a8503af6fdfb868b8c1748d33028d100a8b67e'
+  depends_on "gmp"
+  depends_on "libmpc"
+  depends_on "mpfr"
 
-    depends_on 'gmp'
-    depends_on 'libmpc'
-    depends_on 'mpfr'
+  depends_on "avr-binutils"
 
-    depends_on 'avr-binutils'
+  option "without-cxx", "Don't build the g++ compiler"
 
-    option 'disable-cxx', 'Don\'t build the g++ compiler'
+  deprecated_option "disable-cxx" => "without-cxx"
 
-    def install
-        # The C compiler is always built, C++ can be disabled
-        languages = %w[c]
-        languages << 'c++' unless build.include? 'disable-cxx'
+  def install
+    # The C compiler is always built, C++ can be disabled
+    languages = %w[c]
+    languages << "c++" unless build.without? "cxx"
 
-        args = [
-            "--target=avr",
-            "--prefix=#{prefix}",
+    args = [
+      "--target=avr",
+      "--prefix=#{prefix}",
 
-            "--enable-languages=#{languages.join(',')}",
-            "--with-gnu-as",
-            "--with-gnu-ld",
-            "--with-ld=#{Formula["avr-binutils"].opt_bin/'avr-ld'}",
-            "--with-as=#{Formula["avr-binutils"].opt_bin/'avr-as'}",
+      "--enable-languages=#{languages.join(",")}",
+      "--with-gnu-as",
+      "--with-gnu-ld",
+      "--with-ld=#{Formula["avr-binutils"].opt_bin/"avr-ld"}",
+      "--with-as=#{Formula["avr-binutils"].opt_bin/"avr-as"}",
 
-            "--disable-nls",
-            "--disable-shared",
-            "--disable-threads",
-            "--disable-libssp",
-            "--disable-libstdcxx-pch",
-            "--disable-libgomp",
+      "--disable-nls",
+      "--disable-shared",
+      "--disable-threads",
+      "--disable-libssp",
+      "--disable-libstdcxx-pch",
+      "--disable-libgomp",
 
-            "--with-gmp=#{Formula["gmp"].opt_prefix}",
-            "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
-            "--with-mpc=#{Formula["libmpc"].opt_prefix}",
-            "--with-system-zlib"
-        ]
+      "--with-gmp=#{Formula["gmp"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc"].opt_prefix}",
+      "--with-system-zlib",
+    ]
 
-        mkdir 'build' do
-            system "../configure", *args
-            system "make"
+    mkdir "build" do
+      system "../configure", *args
+      system "make"
 
-            ENV.deparallelize
-            system "make install"
-        end
-
-        # info and man7 files conflict with native gcc
-        info.rmtree
-        man7.rmtree
+      ENV.deparallelize
+      system "make", "install"
     end
-end
 
+    # info and man7 files conflict with native gcc
+    info.rmtree
+    man7.rmtree
+  end
+end

--- a/avr-gcc48.rb
+++ b/avr-gcc48.rb
@@ -1,95 +1,92 @@
-require 'formula'
-
 # print avr-gcc's builtin include paths
 # `avr-gcc -print-prog-name=cc1plus` -v
 
 class AvrGcc48 < Formula
+  homepage "https://www.gnu.org/software/gcc/gcc.html"
+  url "https://ftp.gnu.org/gnu/gcc/gcc-4.8.5/gcc-4.8.5.tar.bz2"
+  mirror "ftp://gcc.gnu.org/pub/gcc/releases/gcc-4.8.5/gcc-4.8.5.tar.bz2"
+  sha256 "22fb1e7e0f68a63cee631d85b20461d1ea6bda162f03096350e38c8d427ecf23"
 
-    homepage 'http://www.gnu.org/software/gcc/gcc.html'
-    url 'http://ftp.gnu.org/gnu/gcc/gcc-4.8.5/gcc-4.8.5.tar.bz2'
-    mirror 'ftp://gcc.gnu.org/pub/gcc/releases/gcc-4.8.5/gcc-4.8.5.tar.bz2'
-    sha256 '22fb1e7e0f68a63cee631d85b20461d1ea6bda162f03096350e38c8d427ecf23'
+  keg_only "You are about to compile an older version of avr-gcc, i.e. avr-gcc #{version}. Please refer to the Caveats section for more information."
 
-    keg_only "You are about to compile an older version of avr-gcc, i.e. avr-gcc #{version}. Please refer to the Caveats section for more information."
+  depends_on "gmp"
+  depends_on "libmpc"
+  depends_on "mpfr"
+  depends_on "cloog"
+  depends_on "isl"
 
-    depends_on 'gmp'
-    depends_on 'libmpc'
-    depends_on 'mpfr'
-    depends_on 'cloog'
-    depends_on 'isl'
+  depends_on "avr-binutils"
 
-    depends_on 'avr-binutils'
+  option "without-cxx", "Don't build the g++ compiler"
 
-    option 'disable-cxx', 'Don\'t build the g++ compiler'
+  deprecated_option "disable-cxx" => "without-cxx"
 
-    def install
-        # The C compiler is always built, C++ can be disabled
-        languages = %w[c]
-        languages << 'c++' unless build.include? 'disable-cxx'
+  def install
+    # The C compiler is always built, C++ can be disabled
+    languages = %w[c]
+    languages << "c++" unless build.without? "cxx"
 
-        args = [
-            "--target=avr",
-            "--prefix=#{prefix}",
+    args = [
+      "--target=avr",
+      "--prefix=#{prefix}",
 
-            "--enable-languages=#{languages.join(',')}",
-            "--with-gnu-as",
-            "--with-gnu-ld",
-            "--with-ld=#{Formula["avr-binutils"].opt_bin/'avr-ld'}",
-            "--with-as=#{Formula["avr-binutils"].opt_bin/'avr-as'}",
+      "--enable-languages=#{languages.join(",")}",
+      "--with-gnu-as",
+      "--with-gnu-ld",
+      "--with-ld=#{Formula["avr-binutils"].opt_bin/"avr-ld"}",
+      "--with-as=#{Formula["avr-binutils"].opt_bin/"avr-as"}",
 
-            "--disable-nls",
-            "--disable-shared",
-            "--disable-threads",
-            "--disable-libssp",
-            "--disable-libstdcxx-pch",
-            "--disable-libgomp",
+      "--disable-nls",
+      "--disable-shared",
+      "--disable-threads",
+      "--disable-libssp",
+      "--disable-libstdcxx-pch",
+      "--disable-libgomp",
 
-            "--with-gmp=#{Formula["gmp"].opt_prefix}",
-            "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
-            "--with-mpc=#{Formula["libmpc"].opt_prefix}",
-            "--with-cloog=#{Formula["cloog"].opt_prefix}",
-            "--with-isl=#{Formula["isl"].opt_prefix}",
-            "--with-system-zlib"
-        ]
+      "--with-gmp=#{Formula["gmp"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc"].opt_prefix}",
+      "--with-cloog=#{Formula["cloog"].opt_prefix}",
+      "--with-isl=#{Formula["isl"].opt_prefix}",
+      "--with-system-zlib",
+    ]
 
-        mkdir 'build' do
-            system "../configure", *args
-            system "make"
+    mkdir "build" do
+      system "../configure", *args
+      system "make"
 
-            ENV.deparallelize
-            system "make install"
-        end
-
-        # info and man7 files conflict with native gcc
-        info.rmtree
-        man7.rmtree
+      ENV.deparallelize
+      system "make", "install"
     end
 
-    def caveats; <<-EOS.undent
-        You are about to compile an older version of avr-gcc, i.e. avr-gcc #{version}.
+    # info and man7 files conflict with native gcc
+    info.rmtree
+    man7.rmtree
+  end
 
-        This formula will not be linked to #{HOMEBREW_PREFIX}/bin in order to avoid conflicts with the default/latest version of avr-gcc, eg. avr-gcc #{Formula["avr-gcc"].version}.
+  def caveats; <<-EOS.undent
+    You are about to compile an older version of avr-gcc, i.e. avr-gcc #{version}.
 
-        Unless you know what you are doing, it is recommended to use avr-gcc #{Formula["avr-gcc"].version}. Simply run the following:
+    This formula will not be linked to #{HOMEBREW_PREFIX}/bin in order to avoid conflicts with the default/latest version of avr-gcc, eg. avr-gcc #{Formula["avr-gcc"].version}.
 
-            $ brew install avr-libc
+    Unless you know what you are doing, it is recommended to use avr-gcc #{Formula["avr-gcc"].version}. Simply run the following:
 
-        To use avr-gcc #{Formula["avr-gcc48"].version}, unlink all the binaries related to other versions of avr-libc before linking this one.
+        $ brew install avr-libc
 
-            # unlink the latest/default avr-gcc #{Formula["avr-gcc"].version}
-            $ brew unlink avr-libc avr-gcc
+    To use avr-gcc #{Formula["avr-gcc48"].version}, unlink all the binaries related to other versions of avr-libc before linking this one.
 
-            # or for an older version of avr-gcc XX
-            $ brew unlink avr-libcXX avr-gccXX
+        # unlink the latest/default avr-gcc #{Formula["avr-gcc"].version}
+        $ brew unlink avr-libc avr-gcc
 
-            # and then link avr-gcc #{Formula["avr-gcc48"].version}
-            $ brew link avr-gcc48 avr-libc48
+        # or for an older version of avr-gcc XX
+        $ brew unlink avr-libcXX avr-gccXX
 
-        Please visite our Github repository for futher information or to report a bug.
+        # and then link avr-gcc #{Formula["avr-gcc48"].version}
+        $ brew link avr-gcc48 avr-libc48
 
-            http://github.com/weareleka/homebrew-avr
-        EOS
-    end
+    Please visite our Github repository for futher information or to report a bug.
 
+        http://github.com/weareleka/homebrew-avr
+    EOS
+  end
 end
-

--- a/avr-gdb.rb
+++ b/avr-gdb.rb
@@ -5,7 +5,7 @@ class AvrGdb < Formula
     homepage 'http://www.gnu.org/software/gdb/'
     url "http://ftp.gnu.org/gnu/gdb/gdb-7.8.2.tar.gz"
     mirror "http://ftpmirror.gnu.org/gnu/gdb/gdb-7.8.2.tar.gz"
-    sha1 '67cfbc6efcff674aaac3af83d281cf9df0839ff9'
+    sha256 'fd9a9784ca24528aac8a4e6b8d7ae7e8cf0784e128cd67a185c986deaf6b9929'
 
     depends_on 'avr-binutils'
 

--- a/avr-gdb.rb
+++ b/avr-gdb.rb
@@ -1,40 +1,37 @@
-require 'formula'
-
 class AvrGdb < Formula
+  homepage "https://www.gnu.org/software/gdb/"
+  url "https://ftp.gnu.org/gnu/gdb/gdb-7.8.2.tar.gz"
+  mirror "https://ftpmirror.gnu.org/gnu/gdb/gdb-7.8.2.tar.gz"
+  sha256 "fd9a9784ca24528aac8a4e6b8d7ae7e8cf0784e128cd67a185c986deaf6b9929"
 
-    homepage 'http://www.gnu.org/software/gdb/'
-    url "http://ftp.gnu.org/gnu/gdb/gdb-7.8.2.tar.gz"
-    mirror "http://ftpmirror.gnu.org/gnu/gdb/gdb-7.8.2.tar.gz"
-    sha256 'fd9a9784ca24528aac8a4e6b8d7ae7e8cf0784e128cd67a185c986deaf6b9929'
+  depends_on "avr-binutils"
 
-    depends_on 'avr-binutils'
+  def install
+    args = [
+      "--target=avr",
+      "--prefix=#{prefix}",
 
-    def install
-        args = [
-            "--target=avr",
-            "--prefix=#{prefix}",
+      "--disable-nls",
+      "--disable-libssp",
+      "--disable-install-libbfd",
+      "--disable-install-libiberty",
 
-            "--disable-nls",
-            "--disable-libssp",
-            "--disable-install-libbfd",
-            "--disable-install-libiberty",
+      "--with-gmp=#{Formula["gmp"].opt_prefix}",
+      "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
+      "--with-mpc=#{Formula["libmpc"].opt_prefix}",
+      "--with-cloog=#{Formula["cloog"].opt_prefix}",
+      "--with-isl=#{Formula["isl"].opt_prefix}",
+    ]
 
-            "--with-gmp=#{Formula["gmp"].opt_prefix}",
-            "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
-            "--with-mpc=#{Formula["libmpc"].opt_prefix}",
-            "--with-cloog=#{Formula["cloog"].opt_prefix}",
-            "--with-isl=#{Formula["isl"].opt_prefix}"
-        ]
+    mkdir "build" do
+      system "../configure", *args
+      system "make"
 
-        mkdir 'build' do
-            system "../configure", *args
-            system "make"
-
-            ENV.deparallelize
-            system "make install"
-        end
-
-        # info conflicts with binutils
-        info.rmtree
+      ENV.deparallelize
+      system "make", "install"
     end
+
+    # info conflicts with binutils
+    info.rmtree
+  end
 end

--- a/avr-libc.rb
+++ b/avr-libc.rb
@@ -1,33 +1,29 @@
-require 'formula'
-
 class AvrLibc < Formula
+  homepage "http://www.nongnu.org/avr-libc/"
+  url "https://download.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
+  sha256 "b2dd7fd2eefd8d8646ef6a325f6f0665537e2f604ed02828ced748d49dc85b97"
 
-    url 'http://download.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2'
-    homepage 'http://www.nongnu.org/avr-libc/'
-    sha256 'b2dd7fd2eefd8d8646ef6a325f6f0665537e2f604ed02828ced748d49dc85b97'
+  depends_on "avr-gcc"
 
-    depends_on 'avr-gcc'
+  def install
+    ENV.delete "CFLAGS"
+    ENV.delete "CXXFLAGS"
+    ENV.delete "LD"
+    ENV.delete "CC"
+    ENV.delete "CXX"
 
-    def install
-        ENV.delete 'CFLAGS'
-        ENV.delete 'CXXFLAGS'
-        ENV.delete 'LD'
-        ENV.delete 'CC'
-        ENV.delete 'CXX'
+    avr_gcc = Formula["avr-gcc"]
 
-        avr_gcc = Formula['avr-gcc']
+    build = `./config.guess`.chomp
 
-        build = `./config.guess`.chomp
+    system "./configure", "--build=#{build}", "--prefix=#{prefix}", "--host=avr"
+    system "make", "install"
 
-        system "./configure", "--build=#{build}", "--prefix=#{prefix}", "--host=avr"
-        system "make install"
+    avr = File.join prefix, "avr"
 
-        avr = File.join prefix, 'avr'
-
-        # copy include and lib files where avr-gcc searches for them
-        # this wouldn't be necessary with a standard prefix
-        ohai "copying #{avr} -> #{avr_gcc.prefix}"
-        cp_r avr, avr_gcc.prefix
-
-    end
+    # copy include and lib files where avr-gcc searches for them
+    # this wouldn't be necessary with a standard prefix
+    ohai "copying #{avr} -> #{avr_gcc.prefix}"
+    cp_r avr, avr_gcc.prefix
+  end
 end

--- a/avr-libc48.rb
+++ b/avr-libc48.rb
@@ -1,62 +1,57 @@
-require 'formula'
-
 class AvrLibc48 < Formula
+  homepage "http://www.nongnu.org/avr-libc/"
+  url "https://download.savannah.gnu.org/releases/avr-libc/avr-libc-1.8.1.tar.bz2"
+  sha256 "c3062a481b6b2c6959dc708571c00b0e26301897ba21171ed92acd0af7c4a969"
 
-    url 'http://download.savannah.gnu.org/releases/avr-libc/avr-libc-1.8.1.tar.bz2'
-    homepage 'http://www.nongnu.org/avr-libc/'
-    sha256 'c3062a481b6b2c6959dc708571c00b0e26301897ba21171ed92acd0af7c4a969'
+  keg_only "You are about to compile avr-libc #{version} with an older version of avr-gcc, i.e. avr-gcc #{Formula["avr-gcc48"].version}. Please refer to the Caveats section for more information."
 
-    keg_only "You are about to compile avr-libc #{version} with an older version of avr-gcc, i.e. avr-gcc #{Formula["avr-gcc48"].version}. Please refer to the Caveats section for more information."
+  depends_on "avr-gcc48"
 
-    depends_on 'avr-gcc48'
+  def install
+    ENV.delete "CFLAGS"
+    ENV.delete "CXXFLAGS"
+    ENV.delete "LD"
+    ENV.delete "CC"
+    ENV.delete "CXX"
 
-    def install
+    avr_gcc = Formula["avr-gcc48"]
 
-        ENV.delete 'CFLAGS'
-        ENV.delete 'CXXFLAGS'
-        ENV.delete 'LD'
-        ENV.delete 'CC'
-        ENV.delete 'CXX'
+    build = `./config.guess`.chomp
 
-        avr_gcc = Formula['avr-gcc48']
+    system "./configure", "--build=#{build}", "--prefix=#{prefix}", "--host=avr"
+    system "make", "install"
 
-        build = `./config.guess`.chomp
+    avr = File.join prefix, "avr"
 
-        system "./configure", "--build=#{build}", "--prefix=#{prefix}", "--host=avr"
-        system "make install"
+    # copy include and lib files where avr-gcc searches for them
+    # this wouldn't be necessary with a standard prefix
+    ohai "copying #{avr} -> #{avr_gcc.prefix}"
+    cp_r avr, avr_gcc.prefix
+  end
 
-        avr = File.join prefix, 'avr'
+  def caveats; <<-EOS.undent
+    You are about to compile avr-libc #{version} with an older version of avr-gcc, i.e. avr-gcc #{Formula["avr-gcc48"].version}.
 
-        # copy include and lib files where avr-gcc searches for them
-        # this wouldn't be necessary with a standard prefix
-        ohai "copying #{avr} -> #{avr_gcc.prefix}"
-        cp_r avr, avr_gcc.prefix
+    This formula will not be linked to #{HOMEBREW_PREFIX}/bin in order to avoid conflicts with another version of avr-libc compiled with a different version of avr-gcc.
 
-    end
+    Unless you know what you are doing, it is recommended to use avr-libc compiled with avr-gcc #{Formula["avr-gcc"].version}. Simply run the following:
 
-    def caveats; <<-EOS.undent
-        You are about to compile avr-libc #{version} with an older version of avr-gcc, i.e. avr-gcc #{Formula["avr-gcc48"].version}.
+        $ brew install avr-libc
 
-        This formula will not be linked to #{HOMEBREW_PREFIX}/bin in order to avoid conflicts with another version of avr-libc compiled with a different version of avr-gcc.
+    To use avr-libc compiled with #{Formula["avr-gcc48"].version}, unlink all the binaries related to other versions of avr-libc before linking this one.
 
-        Unless you know what you are doing, it is recommended to use avr-libc compiled with avr-gcc #{Formula["avr-gcc"].version}. Simply run the following:
+        # unlink the latest/default avr-gcc #{Formula["avr-gcc"].version}
+        $ brew unlink avr-libc avr-gcc
 
-            $ brew install avr-libc
+        # or for an older version of avr-gcc XX
+        $ brew unlink avr-libcXX avr-gccXX
 
-        To use avr-libc compiled with #{Formula["avr-gcc48"].version}, unlink all the binaries related to other versions of avr-libc before linking this one.
+        # and then link avr-gcc #{Formula["avr-gcc48"].version}
+        $ brew link avr-gcc48 avr-libc48
 
-            # unlink the latest/default avr-gcc #{Formula["avr-gcc"].version}
-            $ brew unlink avr-libc avr-gcc
+    Please visite our Github repository for futher information or to report a bug.
 
-            # or for an older version of avr-gcc XX
-            $ brew unlink avr-libcXX avr-gccXX
-
-            # and then link avr-gcc #{Formula["avr-gcc48"].version}
-            $ brew link avr-gcc48 avr-libc48
-
-        Please visite our Github repository for futher information or to report a bug.
-
-            http://github.com/weareleka/homebrew-avr
-        EOS
-    end
+        https://github.com/weareleka/homebrew-avr
+    EOS
+  end
 end


### PR DESCRIPTION
- SHA1 => SHA256.

We've been trying to deprecate SHA1 since [March](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Checksum_Deprecation.md), please try to watch for things like that as a tap author, we don't do it extremely often but leaving behind old checksums & syntax choices allows us to drop ancient code in the core & the end result is more pleasant for everyone.
- Style tweaks to match Homebrew.

Up to you how much of this you want, but since users will start noticing deprecations increasingly this will solve some of them a headache.
