### PR TITLE
Added isl@0.12 and cloog as dependencies.

### DIFF
--- a/avr-gcc48.rb
+++ b/avr-gcc48.rb
@@ -12,6 +12,8 @@ class AvrGcc48 < Formula
   depends_on "gmp"
   depends_on "libmpc"
   depends_on "mpfr"
+  depends_on "isl@0.12"
+  depends_on "cloog"
 
   depends_on "avr-binutils"
 
@@ -45,7 +47,7 @@ class AvrGcc48 < Formula
       "--with-mpfr=#{Formula["mpfr"].opt_prefix}",
       "--with-mpc=#{Formula["libmpc"].opt_prefix}",
       "--with-cloog=#{Formula["cloog"].opt_prefix}",
-      "--with-isl=#{Formula["isl"].opt_prefix}",
+      "--with-isl=#{Formula["isl@0.12"].opt_prefix}",
       "--with-system-zlib",
     ]
 


### PR DESCRIPTION
To build avr-gcc48 isl 0.10, 0.11, 0.12, or 0.14 and cloog 0.17.x
or 0.18.x are required. The current cloog version in homebrew is
0.18.4, but isl is at version 0.18. Therefore a legacy version of
isl is required. I have chosen 0.12, since the cloog package also
depends on this version.