### PR TITLE
AVaRICE

### DIFF
--- a/avarice.rb
+++ b/avarice.rb
@@ -1,0 +1,19 @@
+class Avarice < Formula
+  homepage "http://avarice.sourceforge.net/"
+  head "https://svn.code.sf.net/p/avarice/code/trunk", :using => :svn
+
+  depends_on "binutils"
+  depends_on "hidapi"
+  depends_on "automake"
+
+  def install
+    chdir "avarice" do
+      system "./Bootstrap"
+      system "./configure", "--disable-debug",
+                            "--disable-dependency-tracking",
+                            "--disable-silent-rules",
+                            "--prefix=#{prefix}"
+      system "make", "install"
+    end
+  end
+end


### PR DESCRIPTION
AVaRICE hasn't seen a new release for years, however the code in the repo gets maintained. 
AVaRICE is still the only way to get the ATMEL ICE debuggers to work with gdb, so therefore I think it should be included here!