### PR TITLE
Build with the latest simavr

### DIFF
--- a/simavr.rb
+++ b/simavr.rb
@@ -7,6 +7,7 @@ class Simavr < Formula
   depends_on "libelf"
 
   def install
+    system "make", "all", "HOMEBREW_PREFIX=#{HOMEBREW_PREFIX}", "RELEASE=1"
     system "make", "install", "DESTDIR=#{prefix}", "HOMEBREW_PREFIX=#{HOMEBREW_PREFIX}", "RELEASE=1"
     prefix.install "examples"
   end


### PR DESCRIPTION
This addresses the following build failure

```
==> make install DESTDIR=/usr/local/Cellar/simavr/HEAD-2620f43 HOMEBREW_PREFIX=/usr/local RELEASE=1
Last 15 lines from /Users/jacquesg/Library/Logs/Homebrew/simavr/01.make:
LD obj-x86_64-apple-darwin16.7.0/run_avr.elf
ln -sf obj-x86_64-apple-darwin16.7.0/run_avr.elf run_avr
AR obj-x86_64-apple-darwin16.7.0/libsimavr.a
mkdir -p /usr/local/Cellar/simavr/HEAD-2620f43/include/simavr/avr
mkdir -p /usr/local/Cellar/simavr/HEAD-2620f43/include/simavr/parts
install -m644 sim/*.h /usr/local/Cellar/simavr/HEAD-2620f43/include/simavr/
install -m644 sim_core_*.h /usr/local/Cellar/simavr/HEAD-2620f43/include/simavr/
install -m644 sim/avr/*.h /usr/local/Cellar/simavr/HEAD-2620f43/include/simavr/avr/
install -m644 ../examples/parts/*.h /usr/local/Cellar/simavr/HEAD-2620f43/include/simavr/parts/
mkdir -p /usr/local/Cellar/simavr/HEAD-2620f43/lib
install obj-x86_64-apple-darwin16.7.0/libsimavr.a /usr/local/Cellar/simavr/HEAD-2620f43/lib/
install ../examples/parts/obj-x86_64-apple-darwin16.7.0/libsimavrparts.a /usr/local/Cellar/simavr/HEAD-2620f43/lib/
install: ../examples/parts/obj-x86_64-apple-darwin16.7.0/libsimavrparts.a: No such file or directory
make[1]: *** [install] Error 71
make: *** [install] Error 2

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
https://github.com/osx-cross/homebrew-avr/issues
```