### PR TITLE
Patch patchfile to match patching file

### DIFF
--- a/avr-binutils-size.patch
+++ b/avr-binutils-size.patch
@@ -337,55 +337,54 @@
  
 -  while ((c = getopt_long (argc, argv, "ABHhVvdfotx", long_options,
 +  while ((c = getopt_long (argc, argv, "ABCHhVvdfotx", long_options,
-         (int *) 0)) != EOF)
+ 			   (int *) 0)) != EOF)
      switch (c)
        {
 @@ -150,11 +409,15 @@
-    {
-    case 'B':
-    case 'b':
--     berkeley_format = 1;
-+     format = format_bsd;
-      break;
-    case 'S':
-    case 's':
--     berkeley_format = 0;
-+     format = format_sysv;
-+     break;
-+   case 'A':
-+   case 'a':
-+     format = format_avr;
-      break;
-    default:
-      non_fatal (_("invalid argument to --format: %s"), optarg);
+ 	  {
+ 	  case 'B':
+ 	  case 'b':
+-	    berkeley_format = 1;
++	    format = format_bsd;
+ 	    break;
+ 	  case 'S':
+ 	  case 's':
+-	    berkeley_format = 0;
++	    format = format_sysv;
++	    break;
++	  case 'A':
++	  case 'a':
++	    format = format_avr;
+ 	    break;
+ 	  default:
+ 	    non_fatal (_("invalid argument to --format: %s"), optarg);
 @@ -162,6 +425,10 @@
-    }
-  break;
+ 	  }
+ 	break;
  
 +      case OPTION_MCU:
-+ avrmcu = optarg;
-+ break;
++	avrmcu = optarg;
++	break;
 +
        case OPTION_TARGET:
-  target = optarg;
-  break;
-@@ -190,11 +457,14 @@
-  break;
+ 	target = optarg;
+ 	break;
+@@ -190,10 +457,13 @@
+ 	break;
  
        case 'A':
-- berkeley_format = 0;
-+ format = format_sysv;
-  break;
+-	berkeley_format = 0;
++	format = format_sysv;
+ 	break;
        case 'B':
-- berkeley_format = 1;
-+ format = format_bsd;
-  break;
+-	berkeley_format = 1;
++	format = format_bsd;
++	break;
 +      case 'C':
-+    format = format_avr;
-+    break;
++	format = format_avr;
+ 	break;
        case 'v':
        case 'V':
-  show_version = 1;
 @@ -240,7 +510,7 @@
      for (; optind < argc;)
        display_file (argv[optind++]);

--- a/avr-binutils.rb
+++ b/avr-binutils.rb
@@ -10,7 +10,7 @@ class AvrBinutils < Formula
   # https://github.com/larsimmisch/homebrew-avr/issues/9
   patch :p0 do
     url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/avr-binutils-size.patch"
-    sha256 "43be7d0bf9ddf94a992346a391bca5e77159593150c244f2d421a75ec082f1d7"
+    sha256 "04ec2c64eb46587e26c2ccd1a5d677d6dc73c2ae422ee7f586e8865ff16953b0"
   end
 
   def install


### PR DESCRIPTION
in short, to avoid:
```
==> Applying avr-binutils-size.patch
patching file binutils/size.c
Hunk #8 FAILED at 400.
Hunk #9 FAILED at 409.
Hunk #10 succeeded at 425 with fuzz 2.
Hunk #11 FAILED at 457.
3 out of 13 hunks FAILED -- saving rejects to file binutils/size.c.rej
Error: Failure while executing; `patch -g 0 -f -p0 -i /private/tmp/avr-binutils--patch-20190322-28834-1ko8kt3/avr-binutils-size.patch` exited with 1.
```