### PR TITLE
Added support for ATMega168pb

### DIFF
--- a/Formula/avr-gcc.rb
+++ b/Formula/avr-gcc.rb
@@ -10,6 +10,11 @@ class AvrGcc < Formula
     sha256 "64baadfe6cc0f4947a84cb12d7f0dfaf45bb58b7e92461639596c21e02d97d2c"
   end
 
+  option "with-ATMega168pbSupport", "Add ATMega168pb Support to avr-gcc"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+
   depends_on "avr-binutils"
 
   depends_on "gmp"
@@ -20,10 +25,17 @@ class AvrGcc < Formula
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
 
+  localBuild = build
+
   resource "avr-libc" do
     url "https://download.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
     mirror "https://download-mirror.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
     sha256 "b2dd7fd2eefd8d8646ef6a325f6f0665537e2f604ed02828ced748d49dc85b97"
+
+    patch do
+      url "https://dl.bintray.com/osx-cross/avr-patches/avr-libc-2.0.0-atmega168pb.patch"
+      sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
+    end if localBuild.with? "ATMega168pbSupport"
   end
 
   def version_suffix
@@ -69,6 +81,8 @@ class AvrGcc < Formula
     info.rmtree
     man7.rmtree
 
+    localBuild = build
+
     resource("avr-libc").stage do
       ENV.prepend_path "PATH", bin
 
@@ -80,6 +94,7 @@ class AvrGcc < Formula
 
       build = `./config.guess`.chomp
 
+      system "./bootstrap" if localBuild.with? "ATMega168pbSupport"
       system "./configure", "--build=#{build}", "--prefix=#{prefix}", "--host=avr"
       system "make", "install"
     end

--- a/Formula/avr-gcc@4.rb
+++ b/Formula/avr-gcc@4.rb
@@ -12,6 +12,11 @@ class AvrGccAT4 < Formula
 
   keg_only "it might interfere with other version of avr-gcc. This is useful if you want to have multiple version of avr-gcc installed on the same machine"
 
+  option "with-ATMega168pbSupport", "Add ATMega168pb Support to avr-gcc"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+
   depends_on "avr-binutils"
 
   depends_on "gmp"
@@ -21,11 +26,18 @@ class AvrGccAT4 < Formula
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
+  
+  localBuild = build
 
   resource "avr-libc" do
     url "https://download.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
     mirror "https://download-mirror.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
     sha256 "b2dd7fd2eefd8d8646ef6a325f6f0665537e2f604ed02828ced748d49dc85b97"
+	
+    patch do
+      url "https://dl.bintray.com/osx-cross/avr-patches/avr-libc-2.0.0-atmega168pb.patch"
+      sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
+    end if localBuild.with? "ATMega168pbSupport"
   end
 
   def version_suffix
@@ -80,6 +92,8 @@ class AvrGccAT4 < Formula
     # info and man7 files conflict with native gcc
     info.rmtree
     man7.rmtree
+    
+    localBuild = build
 
     resource("avr-libc").stage do
       ENV.prepend_path "PATH", bin
@@ -92,6 +106,7 @@ class AvrGccAT4 < Formula
 
       build = `./config.guess`.chomp
 
+      system "./bootstrap" if localBuild.with? "ATMega168pbSupport"
       system "./configure", "--build=#{build}", "--prefix=#{prefix}", "--host=avr"
       system "make", "install"
     end

--- a/Formula/avr-gcc@5.rb
+++ b/Formula/avr-gcc@5.rb
@@ -12,6 +12,11 @@ class AvrGccAT5 < Formula
 
   keg_only "it might interfere with other version of avr-gcc. This is useful if you want to have multiple version of avr-gcc installed on the same machine"
 
+  option "with-ATMega168pbSupport", "Add ATMega168pb Support to avr-gcc"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+
   depends_on "avr-binutils"
 
   depends_on "gmp"
@@ -45,11 +50,18 @@ class AvrGccAT5 < Formula
       sha256 "94aaec20c8c7bfd3c41ef8fb7725bd524b1c0392d11a411742303a3465d18d09"
     end
   end
+  
+  localBuild = build
 
   resource "avr-libc" do
     url "https://download.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
     mirror "https://download-mirror.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
     sha256 "b2dd7fd2eefd8d8646ef6a325f6f0665537e2f604ed02828ced748d49dc85b97"
+	
+    patch do
+      url "https://dl.bintray.com/osx-cross/avr-patches/avr-libc-2.0.0-atmega168pb.patch"
+      sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
+    end if localBuild.with? "ATMega168pbSupport"
   end
 
   def version_suffix
@@ -100,6 +112,8 @@ class AvrGccAT5 < Formula
     # info and man7 files conflict with native gcc
     info.rmtree
     man7.rmtree
+    
+    localBuild = build
 
     resource("avr-libc").stage do
       ENV.prepend_path "PATH", bin
@@ -112,6 +126,7 @@ class AvrGccAT5 < Formula
 
       build = `./config.guess`.chomp
 
+      system "./bootstrap" if localBuild.with? "ATMega168pbSupport"
       system "./configure", "--build=#{build}", "--prefix=#{prefix}", "--host=avr"
       system "make", "install"
     end

--- a/Formula/avr-gcc@6.rb
+++ b/Formula/avr-gcc@6.rb
@@ -12,6 +12,11 @@ class AvrGccAT6 < Formula
 
   keg_only "it might interfere with other version of avr-gcc. This is useful if you want to have multiple version of avr-gcc installed on the same machine"
 
+  option "with-ATMega168pbSupport", "Add ATMega168pb Support to avr-gcc"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+
   depends_on "avr-binutils"
 
   depends_on "gmp"
@@ -22,10 +27,17 @@ class AvrGccAT6 < Formula
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
 
+  localBuild = build
+
   resource "avr-libc" do
     url "https://download.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
     mirror "https://download-mirror.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
     sha256 "b2dd7fd2eefd8d8646ef6a325f6f0665537e2f604ed02828ced748d49dc85b97"
+	
+    patch do
+      url "https://dl.bintray.com/osx-cross/avr-patches/avr-libc-2.0.0-atmega168pb.patch"
+      sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
+    end if localBuild.with? "ATMega168pbSupport"
   end
 
   def version_suffix
@@ -74,6 +86,8 @@ class AvrGccAT6 < Formula
 
     # symlink avr-binutils to the bin folder
     bin.install_symlink Formula["avr-binutils"].opt_bin/"*"
+    
+    localBuild = build
 
     resource("avr-libc").stage do
       ENV.prepend_path "PATH", bin
@@ -86,6 +100,7 @@ class AvrGccAT6 < Formula
 
       build = `./config.guess`.chomp
 
+      system "./bootstrap" if localBuild.with? "ATMega168pbSupport"
       system "./configure", "--build=#{build}", "--prefix=#{prefix}", "--host=avr"
       system "make", "install"
     end

--- a/Formula/avr-gcc@7.rb
+++ b/Formula/avr-gcc@7.rb
@@ -12,6 +12,11 @@ class AvrGccAT7 < Formula
 
   keg_only "it might interfere with other version of avr-gcc. This is useful if you want to have multiple version of avr-gcc installed on the same machine"
 
+  option "with-ATMega168pbSupport", "Add ATMega168pb Support to avr-gcc"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+
   depends_on "avr-binutils"
 
   depends_on "gmp"
@@ -21,11 +26,18 @@ class AvrGccAT7 < Formula
 
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
+  
+  localBuild = build
 
   resource "avr-libc" do
     url "https://download.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
     mirror "https://download-mirror.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
     sha256 "b2dd7fd2eefd8d8646ef6a325f6f0665537e2f604ed02828ced748d49dc85b97"
+	
+    patch do
+      url "https://dl.bintray.com/osx-cross/avr-patches/avr-libc-2.0.0-atmega168pb.patch"
+      sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
+    end if localBuild.with? "ATMega168pbSupport"
   end
 
   def version_suffix
@@ -70,6 +82,8 @@ class AvrGccAT7 < Formula
     # info and man7 files conflict with native gcc
     info.rmtree
     man7.rmtree
+    
+    localBuild = build
 
     resource("avr-libc").stage do
       ENV.prepend_path "PATH", bin
@@ -82,6 +96,7 @@ class AvrGccAT7 < Formula
 
       build = `./config.guess`.chomp
 
+      system "./bootstrap" if localBuild.with? "ATMega168pbSupport"
       system "./configure", "--build=#{build}", "--prefix=#{prefix}", "--host=avr"
       system "make", "install"
     end


### PR DESCRIPTION
Hi,

I added support for ATMega168pb by patching avr-libc while installation. Since the patch file is 4,7 MB uncompressed i hesitate to upload it to gist like you did with your patches. The patch is also offered to the avr-libc bugtracker at https://savannah.nongnu.org/projects/avr-libc/ but it seems to take a while until new devices get added.

Chris