### PR TITLE
Update avr-size.patch sha256 value

### DIFF
--- a/Formula/avr-binutils.rb
+++ b/Formula/avr-binutils.rb
@@ -20,7 +20,7 @@ class AvrBinutils < Formula
   # https://github.com/larsimmisch/homebrew-avr/issues/9
   patch do
     url "https://git.archlinux.org/svntogit/community.git/plain/avr-binutils/trunk/avr-size.patch"
-    sha256 "e213fac20bd234542fda595fc9e506170e06db94c26ab07a8af9e7782df5952e"
+    sha256 "7aed303887a8541feba008943d0331dc95dd90a309575f81b7a195650e4cba1e"
   end
 
   def install


### PR DESCRIPTION
I find out that the `avr-size` patch sha256 is a bit different from the latest one.

```
❯❯❯ brew install avr-gcc
Updating Homebrew...
Warning: You are using macOS 10.12.
We (and Apple) do not provide support for this old version.
You will encounter build failures with some formulae.
Please create pull requests instead of asking for help on Homebrew's GitHub,
Discourse, Twitter or IRC. You are responsible for resolving any issues you
experience while you are running this old version.

==> Installing avr-gcc from osx-cross/avr
==> Installing dependencies for osx-cross/avr/avr-gcc: avr-binutils, gmp and isl
==> Installing osx-cross/avr/avr-gcc dependency: avr-binutils
/usr/bin/sandbox-exec -f /private/tmp/homebrew20200221-93124-2moold.sb nice ruby -W0 -I $LOAD_PATH -- /usr/local/Homebrew/Library/Homebrew/build.rb /usr/local/Homebrew/Library/Taps/osx-cross/homebrew-avr/Formula/avr-binutils.rb --verbose
==> Downloading https://ftp.gnu.org/gnu/binutils/binutils-2.33.1.tar.gz
Already downloaded: /Users/strech/Library/Caches/Homebrew/downloads/c166136a074f485663d5a077aebcbb2b7045c28744c9224b5cf6d416e2ce5c36--binutils-2.33.1.tar.gz
==> Verifying c166136a074f485663d5a077aebcbb2b7045c28744c9224b5cf6d416e2ce5c36--binutils-2.33.1.tar.gz checksum
tar xof /Users/strech/Library/Caches/Homebrew/downloads/c166136a074f485663d5a077aebcbb2b7045c28744c9224b5cf6d416e2ce5c36--binutils-2.33.1.tar.gz -C /private/tmp/d20200221-93125-1bwhzl2
cp -pR /private/tmp/d20200221-93125-1bwhzl2/binutils-2.33.1/. /private/tmp/avr-binutils-20200221-93125-189r0gc/binutils-2.33.1
chmod -Rf +w /private/tmp/d20200221-93125-1bwhzl2
==> Downloading https://git.archlinux.org/svntogit/community.git/plain/avr-binutils/trunk/avr-size.patch
/usr/bin/curl -q --globoff --show-error --user-agent Homebrew/2.2.6\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 10.12.6\)\ curl/7.54.0 --fail --location --remote-time --continue-at 0 --output /Users/strech/Library/Caches/Homebrew/downloads/268cf5b894bdc58e0aa71e211c70aa6d2aa3a5476732980438f4f142d7262a9f--avr-size.patch.incomplete https://git.archlinux.org/svntogit/community.git/plain/avr-binutils/trunk/avr-size.patch
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 14829  100 14829    0     0  52815      0 --:--:-- --:--:-- --:--:-- 52960
==> Verifying 268cf5b894bdc58e0aa71e211c70aa6d2aa3a5476732980438f4f142d7262a9f--avr-size.patch checksum
Error: An exception occurred within a child process:
  ChecksumMismatchError: SHA256 mismatch
Expected: e213fac20bd234542fda595fc9e506170e06db94c26ab07a8af9e7782df5952e
  Actual: 7aed303887a8541feba008943d0331dc95dd90a309575f81b7a195650e4cba1e
 Archive: /Users/strech/Library/Caches/Homebrew/downloads/268cf5b894bdc58e0aa71e211c70aa6d2aa3a5476732980438f4f142d7262a9f--avr-size.patch
To retry an incomplete download, remove the file above.
```