### PR TITLE
avr-gcc@8 - remove --disable-multilib to fix ld/linker error - closes #182

### DIFF
--- a/Formula/avr-gcc@8.rb
+++ b/Formula/avr-gcc@8.rb
@@ -91,7 +91,6 @@ class AvrGccAT8 < Formula
       --disable-shared
       --disable-threads
       --disable-libgomp
-      --disable-multilib
 
       --with-dwarf2
       --with-avrlibc


### PR DESCRIPTION
remove --disable-multilib to fix ld/linker error - closes #182