### PR TITLE
avr-gcc - remove --disable-multilib to fix ld/linker error - closes #182

### DIFF
--- a/Formula/avr-gcc.rb
+++ b/Formula/avr-gcc.rb
@@ -87,7 +87,6 @@ class AvrGcc < Formula
       --disable-shared
       --disable-threads
       --disable-libgomp
-      --disable-multilib
 
       --with-dwarf2
       --with-avrlibc


### PR DESCRIPTION
remove --disable-multilib to fix ld/linker error - closes #182