### PR TITLE
remove --disable-multilib to fix ld/linker error - closes osx-cross#182

### DIFF
--- a/Formula/avr-gcc.rb
+++ b/Formula/avr-gcc.rb
@@ -92,7 +92,6 @@ class AvrGcc < Formula
       --disable-shared
       --disable-threads
       --disable-libgomp
-      --disable-multilib
 
       --with-dwarf2
       --with-avrlibc

--- a/Formula/avr-gcc@10.rb
+++ b/Formula/avr-gcc@10.rb
@@ -93,7 +93,6 @@ class AvrGccAT10 < Formula
       --disable-shared
       --disable-threads
       --disable-libgomp
-      --disable-multilib
 
       --with-dwarf2
       --with-avrlibc

--- a/Formula/avr-gcc@8.rb
+++ b/Formula/avr-gcc@8.rb
@@ -92,7 +92,6 @@ class AvrGccAT8 < Formula
       --disable-shared
       --disable-threads
       --disable-libgomp
-      --disable-multilib
 
       --with-dwarf2
       --with-avrlibc


### PR DESCRIPTION
This reapplies the fix from https://github.com/osx-cross/homebrew-avr/commit/c1c8167f6efc8fd9c0efe1420af31c166ae18e09