### PR TITLE
avr-gcc@*.rb: SED=/usr/bin/sed shim workaround unnecessary as of Homebrew/brew#10802 ; fixes #230

### DIFF
--- a/Formula/avr-gcc@10.rb
+++ b/Formula/avr-gcc@10.rb
@@ -103,9 +103,6 @@ class AvrGccAT10 < Formula
       --with-bugurl=https://github.com/osx-cross/homebrew-avr/issues
     ]
 
-    # Avoid reference to sed shim
-    args << "SED=/usr/bin/sed"
-
     mkdir "build" do
       system "../configure", *args
 

--- a/Formula/avr-gcc@5.rb
+++ b/Formula/avr-gcc@5.rb
@@ -100,9 +100,6 @@ class AvrGccAT5 < Formula
       --with-bugurl=https://github.com/osx-cross/homebrew-avr/issues
     ]
 
-    # Avoid reference to sed shim
-    args << "SED=/usr/bin/sed"
-
     mkdir "build" do
       system "../configure", *args
 

--- a/Formula/avr-gcc@8.rb
+++ b/Formula/avr-gcc@8.rb
@@ -103,9 +103,6 @@ class AvrGccAT8 < Formula
       --with-bugurl=https://github.com/osx-cross/homebrew-avr/issues
     ]
 
-    # Avoid reference to sed shim
-    args << "SED=/usr/bin/sed"
-
     mkdir "build" do
       system "../configure", *args
 

--- a/Formula/avr-gcc@9.rb
+++ b/Formula/avr-gcc@9.rb
@@ -99,9 +99,6 @@ class AvrGccAT9 < Formula
       --with-bugurl=https://github.com/osx-cross/homebrew-avr/issues
     ]
 
-    # Avoid reference to sed shim
-    args << "SED=/usr/bin/sed"
-
     mkdir "build" do
       system "../configure", *args
 


### PR DESCRIPTION
~~this was just me messing around with `brew test-bot` because I don't have a local macOS instance~~