### PR TITLE
Updated formulas to use patch for ATMega168pb

### DIFF
--- a/Formula/avr-gcc@10.rb
+++ b/Formula/avr-gcc@10.rb
@@ -57,7 +57,7 @@ class AvrGccAT10 < Formula
 
     if current_build.with? "ATMega168pbSupport"
       patch do
-        url "https://dl.bintray.com/osx-cross/avr-patches/avr-libc-2.0.0-atmega168pb.patch"
+        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/Patch/avr-libc-add-mcu-atmega168pb.patch"
         sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
       end
     end

--- a/Formula/avr-gcc@10.rb
+++ b/Formula/avr-gcc@10.rb
@@ -57,7 +57,7 @@ class AvrGccAT10 < Formula
 
     if current_build.with? "ATMega168pbSupport"
       patch do
-        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/Patch/avr-libc-add-mcu-atmega168pb.patch"
+        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/d2e2566b06b90355952ed996707a0a1a24673cd3/Patch/avr-libc-add-mcu-atmega168pb.patch"
         sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
       end
     end

--- a/Formula/avr-gcc@11.rb
+++ b/Formula/avr-gcc@11.rb
@@ -57,7 +57,7 @@ class AvrGccAT11 < Formula
 
     if current_build.with? "ATMega168pbSupport"
       patch do
-        url "https://dl.bintray.com/osx-cross/avr-patches/avr-libc-2.0.0-atmega168pb.patch"
+        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/Patch/avr-libc-add-mcu-atmega168pb.patch"
         sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
       end
     end

--- a/Formula/avr-gcc@11.rb
+++ b/Formula/avr-gcc@11.rb
@@ -57,7 +57,7 @@ class AvrGccAT11 < Formula
 
     if current_build.with? "ATMega168pbSupport"
       patch do
-        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/Patch/avr-libc-add-mcu-atmega168pb.patch"
+        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/d2e2566b06b90355952ed996707a0a1a24673cd3/Patch/avr-libc-add-mcu-atmega168pb.patch"
         sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
       end
     end

--- a/Formula/avr-gcc@5.rb
+++ b/Formula/avr-gcc@5.rb
@@ -43,8 +43,6 @@ class AvrGccAT5 < Formula
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
 
-  current_build = build
-
   resource "avr-libc" do
     url "https://download.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
     mirror "https://download-mirror.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
@@ -108,8 +106,6 @@ class AvrGccAT5 < Formula
     # info and man7 files conflict with native gcc
     info.rmtree
     man7.rmtree
-
-    current_build = build
 
     resource("avr-libc").stage do
       ENV.prepend_path "PATH", bin

--- a/Formula/avr-gcc@5.rb
+++ b/Formula/avr-gcc@5.rb
@@ -24,8 +24,6 @@ class AvrGccAT5 < Formula
            "This is useful if you want to have multiple version of avr-gcc\n" \
            "installed on the same machine"
 
-  option "with-ATMega168pbSupport", "Add ATMega168pb Support to avr-gcc"
-
   # automake & autoconf are needed to build from source
   # with the ATMega168pbSupport option.
   depends_on "autoconf" => :build
@@ -51,13 +49,6 @@ class AvrGccAT5 < Formula
     url "https://download.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
     mirror "https://download-mirror.savannah.gnu.org/releases/avr-libc/avr-libc-2.0.0.tar.bz2"
     sha256 "b2dd7fd2eefd8d8646ef6a325f6f0665537e2f604ed02828ced748d49dc85b97"
-
-    if current_build.with? "ATMega168pbSupport"
-      patch do
-        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/Patch/avr-libc-add-mcu-atmega168pb.patch"
-        sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
-      end
-    end
   end
 
   def install
@@ -131,7 +122,6 @@ class AvrGccAT5 < Formula
 
       build = `./config.guess`.chomp
 
-      system "./bootstrap" if current_build.with? "ATMega168pbSupport"
       system "./configure", "--build=#{build}", "--prefix=#{prefix}", "--host=avr"
       system "make", "install"
     end

--- a/Formula/avr-gcc@5.rb
+++ b/Formula/avr-gcc@5.rb
@@ -54,7 +54,7 @@ class AvrGccAT5 < Formula
 
     if current_build.with? "ATMega168pbSupport"
       patch do
-        url "https://dl.bintray.com/osx-cross/avr-patches/avr-libc-2.0.0-atmega168pb.patch"
+        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/Patch/avr-libc-add-mcu-atmega168pb.patch"
         sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
       end
     end

--- a/Formula/avr-gcc@8.rb
+++ b/Formula/avr-gcc@8.rb
@@ -57,7 +57,7 @@ class AvrGccAT8 < Formula
 
     if current_build.with? "ATMega168pbSupport"
       patch do
-        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/Patch/avr-libc-add-mcu-atmega168pb.patch"
+        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/d2e2566b06b90355952ed996707a0a1a24673cd3/Patch/avr-libc-add-mcu-atmega168pb.patch"
         sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
       end
     end

--- a/Formula/avr-gcc@8.rb
+++ b/Formula/avr-gcc@8.rb
@@ -57,7 +57,7 @@ class AvrGccAT8 < Formula
 
     if current_build.with? "ATMega168pbSupport"
       patch do
-        url "https://dl.bintray.com/osx-cross/avr-patches/avr-libc-2.0.0-atmega168pb.patch"
+        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/Patch/avr-libc-add-mcu-atmega168pb.patch"
         sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
       end
     end

--- a/Formula/avr-gcc@9.rb
+++ b/Formula/avr-gcc@9.rb
@@ -53,7 +53,7 @@ class AvrGccAT9 < Formula
 
     if current_build.with? "ATMega168pbSupport"
       patch do
-        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/Patch/avr-libc-add-mcu-atmega168pb.patch"
+        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/d2e2566b06b90355952ed996707a0a1a24673cd3/Patch/avr-libc-add-mcu-atmega168pb.patch"
         sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
       end
     end

--- a/Formula/avr-gcc@9.rb
+++ b/Formula/avr-gcc@9.rb
@@ -53,7 +53,7 @@ class AvrGccAT9 < Formula
 
     if current_build.with? "ATMega168pbSupport"
       patch do
-        url "https://dl.bintray.com/osx-cross/avr-patches/avr-libc-2.0.0-atmega168pb.patch"
+        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/Patch/avr-libc-add-mcu-atmega168pb.patch"
         sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
       end
     end


### PR DESCRIPTION
Second part to fix #245

I removed with-ATMega168pbSupport option from avr-gcc@5 since it seems to be incompatible with the patch, which i didn't noticed before.

I compiled every avr-gcc version on my BigSur machine and gave it a small tests, looks good.

Two questions comes to my mind:
- should i include the new "with-newer-mcus" option already in this PR?
- should "with-newer-mcus" replace "with-ATMega168pbSupport" or added?