### PR TITLE
Get avr-gcc@11 to work on Apple ARM systems.

### DIFF
--- a/Formula/avr-gcc@11.rb
+++ b/Formula/avr-gcc@11.rb
@@ -34,8 +34,6 @@ class AvrGccAT11 < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
-  depends_on arch: :x86_64
-
   depends_on "avr-binutils"
 
   depends_on "gmp"
@@ -61,6 +59,14 @@ class AvrGccAT11 < Formula
         sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
       end
     end
+  end
+
+  # This patch fixes a GCC compilation error on Apple ARM systems by adding
+  # a defintion for host_hooks.  Patch comes from
+  # https://github.com/riscv/riscv-gnu-toolchain/issues/800#issuecomment-808722775
+  patch do
+    url "https://gist.githubusercontent.com/DavidEGrayson/88bceb3f4e62f45725ecbb9248366300/raw/c1f515475aff1e1e3985569d9b715edb0f317648/gcc-11-arm-darwin.patch"
+    sha256 "c4e9df9802772ddecb71aa675bb9403ad34c085d1359cb0e45b308ab6db551c6"
   end
 
   def install
@@ -132,20 +138,18 @@ class AvrGccAT11 < Formula
       ENV.delete "CC"
       ENV.delete "CXX"
 
+      # avr-libc ships with outdated config.guess and config.sub scripts that
+      # do not support Apple ARM systems, causing the configure script to fail.
       build_config = `./config.guess`.chomp
+      if build_config.start_with?("-")
+        ENV["ac_cv_build"] = "unknown-apple-darwin"
+        puts "Forcing build system to unknown-apple-darwin."
+      end
 
       system "./bootstrap" if current_build.with? "ATMega168pbSupport"
-      system "./configure", "--build=#{build_config}", "--prefix=#{prefix}", "--host=avr"
+      system "./configure", "--prefix=#{prefix}", "--host=avr"
       system "make", "install"
     end
-  end
-
-  def caveats
-    <<~EOS
-      For Mac computers with Apple silicon, avr-gcc might need Rosetta 2 to work properly.
-      You can learn more about Rosetta 2 here:
-          > https://support.apple.com/en-us/HT211861
-    EOS
   end
 
   test do
@@ -177,7 +181,8 @@ class AvrGccAT11 < Formula
 
     system "#{bin}/avr-gcc", "-mmcu=atmega328p", "-Os", "-c", "hello.c", "-o", "hello.c.o", "--verbose"
     system "#{bin}/avr-gcc", "hello.c.o", "-o", "hello.c.elf"
-    system "avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", "hello.c.elf", "hello.c.hex"
+    system "#{Formula["avr-binutils"].opt_bin}/avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", \
+      "hello.c.elf", "hello.c.hex"
 
     assert_equal `cat hello.c.hex`, hello_c_hex
 
@@ -219,7 +224,8 @@ class AvrGccAT11 < Formula
 
     system "#{bin}/avr-g++", "-mmcu=atmega328p", "-Os", "-c", "hello.cpp", "-o", "hello.cpp.o", "--verbose"
     system "#{bin}/avr-g++", "hello.cpp.o", "-o", "hello.cpp.elf"
-    system "avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", "hello.cpp.elf", "hello.cpp.hex"
+    system "#{Formula["avr-binutils"].opt_bin}/avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", \
+      "hello.cpp.elf", "hello.cpp.hex"
 
     assert_equal `cat hello.cpp.hex`, hello_cpp_hex
   end

--- a/Formula/avr-gcc@11.rb
+++ b/Formula/avr-gcc@11.rb
@@ -140,10 +140,9 @@ class AvrGccAT11 < Formula
 
       # avr-libc ships with outdated config.guess and config.sub scripts that
       # do not support Apple ARM systems, causing the configure script to fail.
-      build_config = `./config.guess`.chomp
-      if build_config.start_with?("-")
-        ENV["ac_cv_build"] = "unknown-apple-darwin"
-        puts "Forcing build system to unknown-apple-darwin."
+      if OS.mac? && Hardware::CPU.arm?
+        ENV["ac_cv_build"] = "aarch64-apple-darwin"
+        puts "Forcing build system to aarch64-apple-darwin."
       end
 
       system "./bootstrap" if current_build.with? "ATMega168pbSupport"


### PR DESCRIPTION
I have a Mac Mini with the new M1 chip and I was able to get the avr-gcc@11.rb formula to build and function properly by making the changes here.

This adds a patch that fixes the missing definition of host_hooks in GCC.  I added that patch to the source tree of this project because that seems like the right place to put it, but I couldn't easily figure out how to fetch the patch from there, so I'm just fetching it from the Internet (like all the other patches used in this project).

For avr-libc, there is no need to provide the `--build` argument.  The avr-libc configure script is perfectly capable of running its own `config.guess` and `config.sub` scripts to figure out what system it is being built on.  So I removed that `--build` argument.  However, avr-libc ships with old versions of those scripts which give invalid results on Apple ARM systems.  Specifically, `config.guess` returns `-apple-darwin20.1.0` and then `config.sub` has an error because that's an invalid system name.  We could download the latest versions of those scripts from GNU and put them into avr-libc, but that sounded tricky, so instead I just run config.guess, see if the problem is going to happen, and then set an environment variable that bypasses both of those scripts if needed.

I used the `file` utility to check that my compiled avr-gcc binary is actually an ARM binary, and removed the caveat about possibly needing Rosetta 2.

Someone should probably test my changes on an Intel Mac using a procedure like this:

1. `brew install --formula ./Formula/avr-gcc@11.rb`
2. Follow the instructions that get printed to add avr-gcc 11 to your PATH.
3. Run `which avr-gcc` to make sure it is the one you just built.
4. Run `brew test avr-gcc@11`.
