### PR TITLE
Get all versions of GCC working on Apple ARM systems.

### DIFF
--- a/Formula/avr-gcc@10.rb
+++ b/Formula/avr-gcc@10.rb
@@ -34,8 +34,6 @@ class AvrGccAT10 < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
-  depends_on arch: :x86_64
-
   depends_on "avr-binutils"
 
   depends_on "gmp"
@@ -61,6 +59,14 @@ class AvrGccAT10 < Formula
         sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
       end
     end
+  end
+
+  # This patch fixes a GCC compilation error on Apple ARM systems by adding
+  # a defintion for host_hooks.  Patch comes from
+  # https://github.com/riscv/riscv-gnu-toolchain/issues/800#issuecomment-808722775
+  patch do
+    url "https://gist.githubusercontent.com/DavidEGrayson/88bceb3f4e62f45725ecbb9248366300/raw/c1f515475aff1e1e3985569d9b715edb0f317648/gcc-11-arm-darwin.patch"
+    sha256 "c4e9df9802772ddecb71aa675bb9403ad34c085d1359cb0e45b308ab6db551c6"
   end
 
   def install
@@ -132,20 +138,17 @@ class AvrGccAT10 < Formula
       ENV.delete "CC"
       ENV.delete "CXX"
 
-      build_config = `./config.guess`.chomp
+      # avr-libc ships with outdated config.guess and config.sub scripts that
+      # do not support Apple ARM systems, causing the configure script to fail.
+      if OS.mac? && Hardware::CPU.arm?
+        ENV["ac_cv_build"] = "aarch64-apple-darwin"
+        puts "Forcing build system to aarch64-apple-darwin."
+      end
 
       system "./bootstrap" if current_build.with? "ATMega168pbSupport"
-      system "./configure", "--build=#{build_config}", "--prefix=#{prefix}", "--host=avr"
+      system "./configure", "--prefix=#{prefix}", "--host=avr"
       system "make", "install"
     end
-  end
-
-  def caveats
-    <<~EOS
-      For Mac computers with Apple silicon, avr-gcc might need Rosetta 2 to work properly.
-      You can learn more about Rosetta 2 here:
-          > https://support.apple.com/en-us/HT211861
-    EOS
   end
 
   test do
@@ -177,7 +180,8 @@ class AvrGccAT10 < Formula
 
     system "#{bin}/avr-gcc", "-mmcu=atmega328p", "-Os", "-c", "hello.c", "-o", "hello.c.o", "--verbose"
     system "#{bin}/avr-gcc", "hello.c.o", "-o", "hello.c.elf"
-    system "avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", "hello.c.elf", "hello.c.hex"
+    system "#{Formula["avr-binutils"].opt_bin}/avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", \
+      "hello.c.elf", "hello.c.hex"
 
     assert_equal `cat hello.c.hex`, hello_c_hex
 
@@ -219,7 +223,8 @@ class AvrGccAT10 < Formula
 
     system "#{bin}/avr-g++", "-mmcu=atmega328p", "-Os", "-c", "hello.cpp", "-o", "hello.cpp.o", "--verbose"
     system "#{bin}/avr-g++", "hello.cpp.o", "-o", "hello.cpp.elf"
-    system "avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", "hello.cpp.elf", "hello.cpp.hex"
+    system "#{Formula["avr-binutils"].opt_bin}/avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", \
+      "hello.cpp.elf", "hello.cpp.hex"
 
     assert_equal `cat hello.cpp.hex`, hello_cpp_hex
   end

--- a/Formula/avr-gcc@5.rb
+++ b/Formula/avr-gcc@5.rb
@@ -31,8 +31,6 @@ class AvrGccAT5 < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
-  depends_on arch: :x86_64
-
   depends_on "avr-binutils"
 
   depends_on "gmp"
@@ -58,6 +56,14 @@ class AvrGccAT5 < Formula
         sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
       end
     end
+  end
+
+  # This patch fixes a GCC compilation error on Apple ARM systems by adding
+  # a defintion for host_hooks.  Patch comes from
+  # https://github.com/riscv/riscv-gnu-toolchain/issues/800#issuecomment-808722775
+  patch do
+    url "https://gist.githubusercontent.com/DavidEGrayson/88bceb3f4e62f45725ecbb9248366300/raw/c1f515475aff1e1e3985569d9b715edb0f317648/gcc-11-arm-darwin.patch"
+    sha256 "c4e9df9802772ddecb71aa675bb9403ad34c085d1359cb0e45b308ab6db551c6"
   end
 
   def install
@@ -129,20 +135,17 @@ class AvrGccAT5 < Formula
       ENV.delete "CC"
       ENV.delete "CXX"
 
-      build = `./config.guess`.chomp
+      # avr-libc ships with outdated config.guess and config.sub scripts that
+      # do not support Apple ARM systems, causing the configure script to fail.
+      if OS.mac? && Hardware::CPU.arm?
+        ENV["ac_cv_build"] = "aarch64-apple-darwin"
+        puts "Forcing build system to aarch64-apple-darwin."
+      end
 
       system "./bootstrap" if current_build.with? "ATMega168pbSupport"
-      system "./configure", "--build=#{build}", "--prefix=#{prefix}", "--host=avr"
+      system "./configure", "--prefix=#{prefix}", "--host=avr"
       system "make", "install"
     end
-  end
-
-  def caveats
-    <<~EOS
-      For Mac computers with Apple silicon, avr-gcc might need Rosetta 2 to work properly.
-      You can learn more about Rosetta 2 here:
-          > https://support.apple.com/en-us/HT211861
-    EOS
   end
 
   test do
@@ -179,7 +182,8 @@ class AvrGccAT5 < Formula
 
     system "#{bin}/avr-gcc", "-mmcu=atmega328p", "-Os", "-c", "hello.c", "-o", "hello.c.o", "--verbose"
     system "#{bin}/avr-gcc", "hello.c.o", "-o", "hello.c.elf"
-    system "avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", "hello.c.elf", "hello.c.hex"
+    system "#{Formula["avr-binutils"].opt_bin}/avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", \
+      "hello.c.elf", "hello.c.hex"
 
     assert_equal `cat hello.c.hex`, hello_c_hex
 
@@ -221,7 +225,8 @@ class AvrGccAT5 < Formula
 
     system "#{bin}/avr-g++", "-mmcu=atmega328p", "-Os", "-c", "hello.cpp", "-o", "hello.cpp.o", "--verbose"
     system "#{bin}/avr-g++", "hello.cpp.o", "-o", "hello.cpp.elf"
-    system "avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", "hello.cpp.elf", "hello.cpp.hex"
+    system "#{Formula["avr-binutils"].opt_bin}/avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", \
+      "hello.cpp.elf", "hello.cpp.hex"
 
     assert_equal `cat hello.cpp.hex`, hello_cpp_hex
   end

--- a/Formula/avr-gcc@8.rb
+++ b/Formula/avr-gcc@8.rb
@@ -34,8 +34,6 @@ class AvrGccAT8 < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
-  depends_on arch: :x86_64
-
   depends_on "avr-binutils"
 
   depends_on "gmp"
@@ -61,6 +59,14 @@ class AvrGccAT8 < Formula
         sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
       end
     end
+  end
+
+  # This patch fixes a GCC compilation error on Apple ARM systems by adding
+  # a defintion for host_hooks.  Patch comes from
+  # https://github.com/riscv/riscv-gnu-toolchain/issues/800#issuecomment-808722775
+  patch do
+    url "https://gist.githubusercontent.com/DavidEGrayson/88bceb3f4e62f45725ecbb9248366300/raw/c1f515475aff1e1e3985569d9b715edb0f317648/gcc-11-arm-darwin.patch"
+    sha256 "c4e9df9802772ddecb71aa675bb9403ad34c085d1359cb0e45b308ab6db551c6"
   end
 
   def install
@@ -132,20 +138,17 @@ class AvrGccAT8 < Formula
       ENV.delete "CC"
       ENV.delete "CXX"
 
-      build_config = `./config.guess`.chomp
+      # avr-libc ships with outdated config.guess and config.sub scripts that
+      # do not support Apple ARM systems, causing the configure script to fail.
+      if OS.mac? && Hardware::CPU.arm?
+        ENV["ac_cv_build"] = "aarch64-apple-darwin"
+        puts "Forcing build system to aarch64-apple-darwin."
+      end
 
       system "./bootstrap" if current_build.with? "ATMega168pbSupport"
-      system "./configure", "--build=#{build_config}", "--prefix=#{prefix}", "--host=avr"
+      system "./configure", "--prefix=#{prefix}", "--host=avr"
       system "make", "install"
     end
-  end
-
-  def caveats
-    <<~EOS
-      For Mac computers with Apple silicon, avr-gcc might need Rosetta 2 to work properly.
-      You can learn more about Rosetta 2 here:
-          > https://support.apple.com/en-us/HT211861
-    EOS
   end
 
   test do
@@ -177,7 +180,8 @@ class AvrGccAT8 < Formula
 
     system "#{bin}/avr-gcc", "-mmcu=atmega328p", "-Os", "-c", "hello.c", "-o", "hello.c.o", "--verbose"
     system "#{bin}/avr-gcc", "hello.c.o", "-o", "hello.c.elf"
-    system "avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", "hello.c.elf", "hello.c.hex"
+    system "#{Formula["avr-binutils"].opt_bin}/avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", \
+      "hello.c.elf", "hello.c.hex"
 
     assert_equal `cat hello.c.hex`, hello_c_hex
 
@@ -219,7 +223,8 @@ class AvrGccAT8 < Formula
 
     system "#{bin}/avr-g++", "-mmcu=atmega328p", "-Os", "-c", "hello.cpp", "-o", "hello.cpp.o", "--verbose"
     system "#{bin}/avr-g++", "hello.cpp.o", "-o", "hello.cpp.elf"
-    system "avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", "hello.cpp.elf", "hello.cpp.hex"
+    system "#{Formula["avr-binutils"].opt_bin}/avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", \
+      "hello.cpp.elf", "hello.cpp.hex"
 
     assert_equal `cat hello.cpp.hex`, hello_cpp_hex
   end

--- a/Formula/avr-gcc@9.rb
+++ b/Formula/avr-gcc@9.rb
@@ -30,8 +30,6 @@ class AvrGccAT9 < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
-  depends_on arch: :x86_64
-
   depends_on "avr-binutils"
 
   depends_on "gmp"
@@ -57,6 +55,14 @@ class AvrGccAT9 < Formula
         sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
       end
     end
+  end
+
+  # This patch fixes a GCC compilation error on Apple ARM systems by adding
+  # a defintion for host_hooks.  Patch comes from
+  # https://github.com/riscv/riscv-gnu-toolchain/issues/800#issuecomment-808722775
+  patch do
+    url "https://gist.githubusercontent.com/DavidEGrayson/88bceb3f4e62f45725ecbb9248366300/raw/c1f515475aff1e1e3985569d9b715edb0f317648/gcc-11-arm-darwin.patch"
+    sha256 "c4e9df9802772ddecb71aa675bb9403ad34c085d1359cb0e45b308ab6db551c6"
   end
 
   def install
@@ -128,20 +134,17 @@ class AvrGccAT9 < Formula
       ENV.delete "CC"
       ENV.delete "CXX"
 
-      build_config = `./config.guess`.chomp
+      # avr-libc ships with outdated config.guess and config.sub scripts that
+      # do not support Apple ARM systems, causing the configure script to fail.
+      if OS.mac? && Hardware::CPU.arm?
+        ENV["ac_cv_build"] = "aarch64-apple-darwin"
+        puts "Forcing build system to aarch64-apple-darwin."
+      end
 
       system "./bootstrap" if current_build.with? "ATMega168pbSupport"
-      system "./configure", "--build=#{build_config}", "--prefix=#{prefix}", "--host=avr"
+      system "./configure", "--prefix=#{prefix}", "--host=avr"
       system "make", "install"
     end
-  end
-
-  def caveats
-    <<~EOS
-      For Mac computers with Apple silicon, avr-gcc might need Rosetta 2 to work properly.
-      You can learn more about Rosetta 2 here:
-          > https://support.apple.com/en-us/HT211861
-    EOS
   end
 
   test do
@@ -178,7 +181,8 @@ class AvrGccAT9 < Formula
 
     system "#{bin}/avr-gcc", "-mmcu=atmega328p", "-Os", "-c", "hello.c", "-o", "hello.c.o", "--verbose"
     system "#{bin}/avr-gcc", "hello.c.o", "-o", "hello.c.elf"
-    system "avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", "hello.c.elf", "hello.c.hex"
+    system "#{Formula["avr-binutils"].opt_bin}/avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", \
+      "hello.c.elf", "hello.c.hex"
 
     assert_equal `cat hello.c.hex`, hello_c_hex
 
@@ -226,7 +230,8 @@ class AvrGccAT9 < Formula
 
     system "#{bin}/avr-g++", "-mmcu=atmega328p", "-Os", "-c", "hello.cpp", "-o", "hello.cpp.o", "--verbose"
     system "#{bin}/avr-g++", "hello.cpp.o", "-o", "hello.cpp.elf"
-    system "avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", "hello.cpp.elf", "hello.cpp.hex"
+    system "#{Formula["avr-binutils"].opt_bin}/avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data", \
+      "hello.cpp.elf", "hello.cpp.hex"
 
     assert_equal `cat hello.cpp.hex`, hello_cpp_hex
   end

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ AVR is a popular family of micro-controllers, used for example in the [Arduino] 
 ## Current Versions
 
 - GCC 9.3.0 - **default**, provided as `avr-gcc` or `avr-gcc@9`
+- GCC 5.5.0 - provided as `avr-gcc@5`
 - GCC 8.4.0 - provided as `avr-gcc@8`
 - GCC 10.2.0 - provided as `avr-gcc@10`
+- GCC 11.1.0 - provided as `avr-gcc@11`
 - Binutils 2.35.1 - provided as `avr-binutils`
-- AVR Libc 2.0.0 - provided as a ressource for each GCC formula
+- AVR Libc 2.0.0 - provided as a resource for each GCC formula
 - GDB 10.1 - provided as `avr-gdb`
 
-Support for older GCC versions (4, 5, 6, 7) has been removed. Please, raise an issue if you need one back.
+Support for older GCC versions (4, 6, 7) has been removed. Please, raise an issue if you need one back.
 
 ## Installing homebrew-avr formulae
 


### PR DESCRIPTION
This just takes the changes that we did to avr-gcc@11 for ARM support and applies them to all the other GCC versions.

The patch I used for GCC 11 happens to work for all the other versions, and I tested that it is at least necessary for GCC 9.  I assume it is necessary for all the other versions too.

I did not test this pull request out on any hardware, but after installing the formulas successfuly on an M1 Mac Mini, I ran these commands successfully:

    brew test ./Formula/avr-gcc@*
    brew audit ./Formula/avr-gcc@*
    brew style ./Formula/avr-gcc@*

I also used commands like `diff -ur avr-gcc@11.rb avr-gcc@9.rb` to make sure that I remembered to apply all the changes.

And I added GCC 11 and GCC 5 to the README since it seems like they were missing.