### PR TITLE
Fix broken avr-size patch link

### DIFF
--- a/Formula/avr-binutils.rb
+++ b/Formula/avr-binutils.rb
@@ -20,7 +20,7 @@ class AvrBinutils < Formula
   # Support for -C in avr-size. See issue
   # https://github.com/larsimmisch/homebrew-avr/issues/9
   patch do
-    url "https://git.archlinux.org/svntogit/community.git/plain/avr-binutils/trunk/avr-size.patch"
+    url "https://raw.githubusercontent.com/archlinux/svntogit-community/c3efadcb76f4d8b1a3784015e7c472f59dbfa7de/avr-binutils/repos/community-x86_64/avr-size.patch"
     sha256 "7aed303887a8541feba008943d0331dc95dd90a309575f81b7a195650e4cba1e"
   end
 


### PR DESCRIPTION
git.archlinux.org is no more - but the GitHub repo for `svntogit-community` is still around.

(see https://lists.archlinux.org/pipermail/arch-dev-public/2021-June/030466.html)