### PR TITLE
Unknown symbol format elf32-avr fix for avr-gdb

### DIFF
--- a/Formula/avr-binutils.rb
+++ b/Formula/avr-binutils.rb
@@ -26,7 +26,7 @@ class AvrBinutils < Formula
 
   # Fix symbol formate elf32-avr unknown in gdb
   patch do
-    url "https://raw.githubusercontent.com/failsafe89/homebrew-avr/gdb-elf-fix/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
+    url "https://raw.githubusercontent.com/failsafe89/homebrew-avr/master/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
     sha256 "0ebb14c51934677c783cb949cd5187440743a23ee5ccc579e16009ea13e2b079"
   end
 

--- a/Formula/avr-binutils.rb
+++ b/Formula/avr-binutils.rb
@@ -27,7 +27,7 @@ class AvrBinutils < Formula
   # Fix symbol formate elf32-avr unknown in gdb
   patch do
     url "https://raw.githubusercontent.com/failsafe89/homebrew-avr/master/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
-    sha256 "ec71a652e7b8c86179fe8144a89dbc5bc10c4ba72c86f95052de497abcc7d759"
+    sha256 "4c72bad2d4935feeecb2febf3435ad7df3a176f82e6520ea79b4b281bf8a381c"
   end
 
   def install

--- a/Formula/avr-binutils.rb
+++ b/Formula/avr-binutils.rb
@@ -27,7 +27,7 @@ class AvrBinutils < Formula
   # Fix symbol formate elf32-avr unknown in gdb
   patch do
     url "https://raw.githubusercontent.com/failsafe89/homebrew-avr/master/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
-    sha256 "4c72bad2d4935feeecb2febf3435ad7df3a176f82e6520ea79b4b281bf8a381c"
+    sha256 "7954f85d2e0f628c261bdd486df8e1a229bc5bacc6ea4a0da003913cb96543f6"
   end
 
   def install

--- a/Formula/avr-binutils.rb
+++ b/Formula/avr-binutils.rb
@@ -24,6 +24,12 @@ class AvrBinutils < Formula
     sha256 "7aed303887a8541feba008943d0331dc95dd90a309575f81b7a195650e4cba1e"
   end
 
+  # Fix symbol formate elf32-avr unknown in gdb
+  patch do
+    url "https://raw.githubusercontent.com/failsafe89/homebrew-avr/gdb-elf-fix/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
+    sha256 "0ebb14c51934677c783cb949cd5187440743a23ee5ccc579e16009ea13e2b079"
+  end
+
   def install
     args = [
       "--prefix=#{prefix}",

--- a/Formula/avr-binutils.rb
+++ b/Formula/avr-binutils.rb
@@ -27,7 +27,7 @@ class AvrBinutils < Formula
   # Fix symbol formate elf32-avr unknown in gdb
   patch do
     url "https://raw.githubusercontent.com/failsafe89/homebrew-avr/master/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
-    sha256 "0ebb14c51934677c783cb949cd5187440743a23ee5ccc579e16009ea13e2b079"
+    sha256 "ec71a652e7b8c86179fe8144a89dbc5bc10c4ba72c86f95052de497abcc7d759"
   end
 
   def install

--- a/Formula/avr-gdb.rb
+++ b/Formula/avr-gdb.rb
@@ -21,7 +21,7 @@ class AvrGdb < Formula
   # Fix symbol formate elf32-avr unknown in gdb
   patch do
     url "https://raw.githubusercontent.com/failsafe89/homebrew-avr/master/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
-    sha256 "ec71a652e7b8c86179fe8144a89dbc5bc10c4ba72c86f95052de497abcc7d759"
+    sha256 "4c72bad2d4935feeecb2febf3435ad7df3a176f82e6520ea79b4b281bf8a381c"
   end
 
   def install

--- a/Formula/avr-gdb.rb
+++ b/Formula/avr-gdb.rb
@@ -21,7 +21,7 @@ class AvrGdb < Formula
   # Fix symbol formate elf32-avr unknown in gdb
   patch do
     url "https://raw.githubusercontent.com/failsafe89/homebrew-avr/master/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
-    sha256 "4c72bad2d4935feeecb2febf3435ad7df3a176f82e6520ea79b4b281bf8a381c"
+    sha256 "7954f85d2e0f628c261bdd486df8e1a229bc5bacc6ea4a0da003913cb96543f6"
   end
 
   def install

--- a/Formula/avr-gdb.rb
+++ b/Formula/avr-gdb.rb
@@ -18,6 +18,12 @@ class AvrGdb < Formula
   uses_from_macos "expat"
   uses_from_macos "ncurses"
 
+  # Fix symbol formate elf32-avr unknown in gdb
+  patch do
+    url "https://raw.githubusercontent.com/failsafe89/homebrew-avr/master/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
+    sha256 "ec71a652e7b8c86179fe8144a89dbc5bc10c4ba72c86f95052de497abcc7d759"
+  end
+
   def install
     args = %W[
       --target=avr

--- a/Patch/avr-binutils-elf-bfd-gdb-fix.patch
+++ b/Patch/avr-binutils-elf-bfd-gdb-fix.patch
@@ -1,0 +1,14 @@
+Fix avr-gdb issue with elf32-avr file format reading
+
+Source: 
+===========================================================
+--- bfd/elf-bfd.h
++++ bfd/elf-bfd.h
+@@ -21,7 +21,6 @@
+
+ #ifndef _LIBELF_H_
+ #define _LIBELF_H_ 1
++#include <string.h>
+
+ #include "elf/common.h"
+ #include "elf/external.h"

--- a/Patch/avr-binutils-elf-bfd-gdb-fix.patch
+++ b/Patch/avr-binutils-elf-bfd-gdb-fix.patch
@@ -1,10 +1,8 @@
-Fix avr-gdb issue with elf32-avr file format reading
-
-Source: 
-===========================================================
---- bfd/elf-bfd.h
-+++ bfd/elf-bfd.h
-@@ -21,7 +21,6 @@
+diff --git a/bfd/elf-bfd.h b/bfd/elf-bfd.h
+index 15206b4..63dcf99 100644
+--- a/bfd/elf-bfd.h
++++ b/bfd/elf-bfd.h
+@@ -21,6 +21,7 @@
 
  #ifndef _LIBELF_H_
  #define _LIBELF_H_ 1

--- a/Patch/avr-binutils-elf-bfd-gdb-fix.patch
+++ b/Patch/avr-binutils-elf-bfd-gdb-fix.patch
@@ -10,4 +10,3 @@ index 15206b4..63dcf99 100644
 
  #include "elf/common.h"
  #include "elf/external.h"
- 

--- a/Patch/avr-binutils-elf-bfd-gdb-fix.patch
+++ b/Patch/avr-binutils-elf-bfd-gdb-fix.patch
@@ -10,3 +10,4 @@ index 15206b4..63dcf99 100644
 
  #include "elf/common.h"
  #include "elf/external.h"
+ 


### PR DESCRIPTION
Added patch suggested by https://github.com/osx-cross/homebrew-avr/issues/251#issuecomment-879036177 to resolve issue loading avr elf files into avr-gdb.