### PR TITLE
Add patch file for gdb .elf fix

### DIFF
--- a/Patch/avr-binutils-elf-bfd-gdb-fix.patch
+++ b/Patch/avr-binutils-elf-bfd-gdb-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/bfd/elf-bfd.h b/bfd/elf-bfd.h
+index 15206b4..63dcf99 100644
+--- a/bfd/elf-bfd.h
++++ b/bfd/elf-bfd.h
+@@ -21,6 +21,7 @@
+
+ #ifndef _LIBELF_H_
+ #define _LIBELF_H_ 1
++#include <string.h>
+
+ #include "elf/common.h"
+ #include "elf/external.h"


### PR DESCRIPTION
Solves the issue raised by #251 by implementing the fix proposed by #255.

This PR simply includes the patch file. A subsequent PR will introduce the code that applies the patch to `elf-gdb.h` using the resulting Github URL created for the patch file.