### PR TITLE
Apply .elf patch for binutils and gdb builds

### DIFF
--- a/Formula/avr-binutils.rb
+++ b/Formula/avr-binutils.rb
@@ -26,6 +26,12 @@ class AvrBinutils < Formula
     sha256 "7aed303887a8541feba008943d0331dc95dd90a309575f81b7a195650e4cba1e"
   end
 
+  # Fix symbol format elf32-avr unknown in gdb
+  patch do
+    url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
+    sha256 "7954f85d2e0f628c261bdd486df8e1a229bc5bacc6ea4a0da003913cb96543f6"
+  end
+
   def install
     args = [
       "--prefix=#{prefix}",

--- a/Formula/avr-binutils.rb
+++ b/Formula/avr-binutils.rb
@@ -28,7 +28,7 @@ class AvrBinutils < Formula
 
   # Fix symbol format elf32-avr unknown in gdb
   patch do
-    url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
+    url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/18d50ba2a168a3b90a25c96e4bc4c053df77d7dc/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
     sha256 "7954f85d2e0f628c261bdd486df8e1a229bc5bacc6ea4a0da003913cb96543f6"
   end
 

--- a/Formula/avr-gdb.rb
+++ b/Formula/avr-gdb.rb
@@ -18,6 +18,12 @@ class AvrGdb < Formula
   uses_from_macos "expat"
   uses_from_macos "ncurses"
 
+  # Fix symbol format elf32-avr unknown in gdb
+  patch do
+    url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
+    sha256 "7954f85d2e0f628c261bdd486df8e1a229bc5bacc6ea4a0da003913cb96543f6"
+  end
+
   def install
     args = %W[
       --target=avr

--- a/Formula/avr-gdb.rb
+++ b/Formula/avr-gdb.rb
@@ -20,7 +20,7 @@ class AvrGdb < Formula
 
   # Fix symbol format elf32-avr unknown in gdb
   patch do
-    url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/master/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
+    url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/18d50ba2a168a3b90a25c96e4bc4c053df77d7dc/Patch/avr-binutils-elf-bfd-gdb-fix.patch"
     sha256 "7954f85d2e0f628c261bdd486df8e1a229bc5bacc6ea4a0da003913cb96543f6"
   end
 


### PR DESCRIPTION
Applies the patch from #259 to the binutils and gdb formulae in order to fix #251.