### PR TITLE
Fix Ventura build

### DIFF
--- a/Formula/avr-binutils.rb
+++ b/Formula/avr-binutils.rb
@@ -16,6 +16,10 @@ class AvrBinutils < Formula
 
   uses_from_macos "zlib"
 
+  on_ventura do
+    depends_on "texinfo" => :build
+  end
+
   on_linux do
     depends_on "gpatch" => :build
   end


### PR DESCRIPTION
Per #277, building fails on macOS Ventura due to missing `makeinfo`; this PR adds `texinfo` as a build requirement. I _currently_ only have an ARM Mac on Ventura, though I may be upgrading my work Intel machine within the next few days, and could possibly test there; but if anybody knows if this is broken on only ARM or on both ARM/x64, we could scope this accordingly.

Closes #277
