### PR TITLE
avr-gdb: add texinfo build dependency on Ventura

### DIFF
--- a/Formula/avr-gdb.rb
+++ b/Formula/avr-gdb.rb
@@ -16,7 +16,11 @@ class AvrGdb < Formula
   depends_on "avr-binutils"
 
   depends_on "python@3.9"
-
+  
+  on_ventura do
+    depends_on "texinfo" => :build
+  end
+  
   uses_from_macos "expat"
   uses_from_macos "ncurses"
 

--- a/Formula/avr-gdb.rb
+++ b/Formula/avr-gdb.rb
@@ -16,13 +16,13 @@ class AvrGdb < Formula
   depends_on "avr-binutils"
 
   depends_on "python@3.9"
-  
+
+  uses_from_macos "expat"
+  uses_from_macos "ncurses"
+
   on_ventura do
     depends_on "texinfo" => :build
   end
-  
-  uses_from_macos "expat"
-  uses_from_macos "ncurses"
 
   # Fix symbol format elf32-avr unknown in gdb
   patch do


### PR DESCRIPTION
Fixes #284 .

Note this is the same resolution as commit 0f0a6cd365c6c24d21345be8f157bea32d902012 so the issues are much the same. And despite `avr-gdb` depending on `avr-binutils`, it seems the build dependency is not transitive so the fix has to be repeated here.