### PR TITLE
Add patch to fix argument type mismatch when compiling GCC 11

### DIFF
--- a/Patch/avr-gcc-11-fix-argument-type-mismatch.patch
+++ b/Patch/avr-gcc-11-fix-argument-type-mismatch.patch
@@ -1,0 +1,20 @@
+--- a/gcc/config/avr/avr.c	2022-10-08 19:18:33.000000000 +0200
++++ b/gcc/config/avr/avr.patched.c	2022-10-08 19:19:34.000000000 +0200
+@@ -10196,7 +10196,7 @@
+    to track need of __do_copy_data.  */
+ 
+ static void
+-avr_output_data_section_asm_op (const void *data)
++avr_output_data_section_asm_op (const char *data)
+ {
+   avr_need_copy_data_p = true;
+ 
+@@ -10209,7 +10209,7 @@
+    to track need of __do_clear_bss.  */
+ 
+ static void
+-avr_output_bss_section_asm_op (const void *data)
++avr_output_bss_section_asm_op (const char *data)
+ {
+   avr_need_clear_bss_p = true;
+ 


### PR DESCRIPTION
This PR should fix issue #280.

After merging, the patch url will have to be adapted to point at this repo.