### PR TITLE
Fix brew test by avoiding to use ENV.clear in formulas

### DIFF
--- a/Formula/avr-gcc@10.rb
+++ b/Formula/avr-gcc@10.rb
@@ -149,7 +149,7 @@ class AvrGccAT10 < Formula
   end
 
   test do
-    ENV.clear
+    ENV.delete "CPATH"
 
     hello_c = <<~EOS
       #define F_CPU 8000000UL

--- a/Formula/avr-gcc@11.rb
+++ b/Formula/avr-gcc@11.rb
@@ -156,7 +156,7 @@ class AvrGccAT11 < Formula
   end
 
   test do
-    ENV.clear
+    ENV.delete "CPATH"
 
     hello_c = <<~EOS
       #define F_CPU 8000000UL

--- a/Formula/avr-gcc@12.rb
+++ b/Formula/avr-gcc@12.rb
@@ -157,7 +157,7 @@ class AvrGccAT12 < Formula
   end
 
   test do
-    ENV.clear
+    ENV.delete "CPATH"
 
     version_output = "gcc version 12.2.0 (Homebrew AVR GCC 12.2.0)"
     assert_match version_output, `#{bin}/avr-gcc -v 2>&1`

--- a/Formula/avr-gcc@5.rb
+++ b/Formula/avr-gcc@5.rb
@@ -135,7 +135,7 @@ class AvrGccAT5 < Formula
   end
 
   test do
-    ENV.clear
+    ENV.delete "CPATH"
 
     hello_c = <<~EOS
       #define F_CPU 8000000UL

--- a/Formula/avr-gcc@8.rb
+++ b/Formula/avr-gcc@8.rb
@@ -150,7 +150,7 @@ class AvrGccAT8 < Formula
   end
 
   test do
-    ENV.clear
+    ENV.delete "CPATH"
 
     hello_c = <<~EOS
       #define F_CPU 8000000UL

--- a/Formula/avr-gcc@9.rb
+++ b/Formula/avr-gcc@9.rb
@@ -148,7 +148,7 @@ class AvrGccAT9 < Formula
   end
 
   test do
-    ENV.clear
+    ENV.delete "CPATH"
 
     hello_c = <<~EOS
       #define F_CPU 8000000UL


### PR DESCRIPTION
Following [advice](https://github.com/Homebrew/brew/issues/14752) by the homebrew core developers, clearing the shell environment is not a great idea for several reasons. In fact, it is not done in any of the other core formulas.
I have checked all gcc versions locally on macOS Ventura on ARM, and apparently only CPATH needs to be unset.
