### PR TITLE
Add macOS 14 M1 runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-13]
+        os: [macos-12, macos-13, macos-14]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
According to [this issue](https://github.com/actions/runner-images/issues/9254) M1 runners for Sonoma are now available. Let's see if this works :)

upload-artifact tag was also changed due to https://github.com/Homebrew/brew/pull/16347