### PR TITLE
Fix avr-binutils dependencies

### DIFF
--- a/Formula/avarice.rb
+++ b/Formula/avarice.rb
@@ -14,9 +14,9 @@ class Avarice < Formula
   end
 
   depends_on "automake"
-  depends_on "avr-binutils"
   depends_on "hidapi"
   depends_on "libusb-compat"
+  depends_on "osx-cross/avr/avr-binutils"
 
   def install
     system "./Bootstrap" if build.head?

--- a/Formula/avr-gcc@10.rb
+++ b/Formula/avr-gcc@10.rb
@@ -34,12 +34,11 @@ class AvrGccAT10 < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
-  depends_on "avr-binutils"
-
   depends_on "gmp"
   depends_on "isl"
   depends_on "libmpc"
   depends_on "mpfr"
+  depends_on "osx-cross/avr/avr-binutils"
 
   uses_from_macos "zlib"
 

--- a/Formula/avr-gcc@11.rb
+++ b/Formula/avr-gcc@11.rb
@@ -33,12 +33,11 @@ class AvrGccAT11 < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
-  depends_on "avr-binutils"
-
   depends_on "gmp"
   depends_on "isl"
   depends_on "libmpc"
   depends_on "mpfr"
+  depends_on "osx-cross/avr/avr-binutils"
 
   uses_from_macos "zlib"
 

--- a/Formula/avr-gcc@12.rb
+++ b/Formula/avr-gcc@12.rb
@@ -33,12 +33,11 @@ class AvrGccAT12 < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
-  depends_on "avr-binutils"
-
   depends_on "gmp"
   depends_on "isl"
   depends_on "libmpc"
   depends_on "mpfr"
+  depends_on "osx-cross/avr/avr-binutils"
 
   uses_from_macos "zlib"
 

--- a/Formula/avr-gcc@5.rb
+++ b/Formula/avr-gcc@5.rb
@@ -31,12 +31,11 @@ class AvrGccAT5 < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
-  depends_on "avr-binutils"
-
   depends_on "gmp"
   depends_on "isl@0.18"
   depends_on "libmpc"
   depends_on "mpfr"
+  depends_on "osx-cross/avr/avr-binutils"
 
   uses_from_macos "zlib"
 

--- a/Formula/avr-gcc@8.rb
+++ b/Formula/avr-gcc@8.rb
@@ -38,12 +38,11 @@ class AvrGccAT8 < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
-  depends_on "avr-binutils"
-
   depends_on "gmp"
   depends_on "isl"
   depends_on "libmpc"
   depends_on "mpfr"
+  depends_on "osx-cross/avr/avr-binutils"
 
   uses_from_macos "zlib"
 

--- a/Formula/avr-gcc@9.rb
+++ b/Formula/avr-gcc@9.rb
@@ -29,12 +29,11 @@ class AvrGccAT9 < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
-  depends_on "avr-binutils"
-
   depends_on "gmp"
   depends_on "isl"
   depends_on "libmpc"
   depends_on "mpfr"
+  depends_on "osx-cross/avr/avr-binutils"
 
   uses_from_macos "zlib"
 

--- a/Formula/avr-gdb.rb
+++ b/Formula/avr-gdb.rb
@@ -14,7 +14,7 @@ class AvrGdb < Formula
     sha256 big_sur:  "8768ff3f7ef4c90864a18b1dc15817adc251304b4e74ef3ff6ac3b2595e9f6af"
   end
 
-  depends_on "avr-binutils"
+  depends_on "osx-cross/avr/avr-binutils"
 
   depends_on "python@3.9"
 

--- a/Formula/simavr.rb
+++ b/Formula/simavr.rb
@@ -12,8 +12,8 @@ class Simavr < Formula
     sha256 cellar: :any_skip_relocation, catalina: "2040a34f2d283aaa8398b23f2bc4c08f0f7192275df5c4957661fc56d7c62866"
   end
 
-  depends_on "avr-gcc"
   depends_on "libelf"
+  depends_on "osx-cross/avr/avr-gcc"
 
   def install
     ENV.deparallelize


### PR DESCRIPTION
It appears the fully qualified name is required for other packages to pass the `brew deps` check: https://github.com/qmk/homebrew-qmk/actions/runs/8319148121/job/22761999493?pr=79

```
==> brew deps --tree --annotate --include-build --include-test qmk/qmk/qmk
Error: No available formula with the name "avr-binutils". Did you mean cargo-binutils?
Error: Process completed with exit code 1.
```