### PR TITLE
Change: avr-gcc@14 formula to use avr-libc 2.2.1

### DIFF
--- a/Formula/avr-gcc@14.rb
+++ b/Formula/avr-gcc@14.rb
@@ -47,16 +47,8 @@ class AvrGccAT14 < Formula
   current_build = build
 
   resource "avr-libc" do
-    url "https://download.savannah.gnu.org/releases/avr-libc/avr-libc-2.1.0.tar.bz2"
-    mirror "https://download-mirror.savannah.gnu.org/releases/avr-libc/avr-libc-2.1.0.tar.bz2"
-    sha256 "0b84cee5c08b5d5cba67c36125e5aaa85251bc9accfba5773bfa87bc34b654e8"
-
-    if current_build.with? "ATMega168pbSupport"
-      patch do
-        url "https://raw.githubusercontent.com/osx-cross/homebrew-avr/d2e2566b06b90355952ed996707a0a1a24673cd3/Patch/avr-libc-add-mcu-atmega168pb.patch"
-        sha256 "7a2bf2e11cfd9335e8e143eecb94480b4871e8e1ac54392c2ee2d89010b43711"
-      end
-    end
+    url "https://github.com/avrdudes/avr-libc/releases/download/avr-libc-2_2_1-release/avr-libc-2.2.1.tar.bz2"
+    sha256 "006a6306cbbc938c3bdb583ac54f93fe7d7c8cf97f9cde91f91c6fb0273ab465"
   end
 
   # Branch from the Darwin maintainer of GCC, with a few generic fixes and

--- a/Formula/avr-gcc@14.rb
+++ b/Formula/avr-gcc@14.rb
@@ -44,8 +44,6 @@ class AvrGccAT14 < Formula
   # GCC bootstraps itself, so it is OK to have an incompatible C++ stdlib
   cxxstdlib_check :skip
 
-  current_build = build
-
   resource "avr-libc" do
     url "https://github.com/avrdudes/avr-libc/releases/download/avr-libc-2_2_1-release/avr-libc-2.2.1.tar.bz2"
     sha256 "006a6306cbbc938c3bdb583ac54f93fe7d7c8cf97f9cde91f91c6fb0273ab465"


### PR DESCRIPTION
`avr-libc` 2.2.1 adds support for many new Microchip devices.

[The changes to io.h](https://github.com/avrdudes/avr-libc/compare/avr-libc-2_1_0-release...avr-libc-2_2_1-release#diff-58346ac4bb680ebabf4469aca65646ff9fa2585d4b8ad746579688b1a1aaf074) give an idea of the number of new chips supported.

Another user opened a PR for this which ended up becoming stale due to some outstanding style changes and the desire to not change multiple formulae per PR, so this is re-raised as a separate PR per GCC version.