### PR TITLE
Upgrade avr-binutils to 2.44

### DIFF
--- a/Formula/avr-binutils.rb
+++ b/Formula/avr-binutils.rb
@@ -2,17 +2,13 @@ class AvrBinutils < Formula
   desc "GNU Binutils for the AVR target"
   homepage "https://www.gnu.org/software/binutils"
 
-  url "https://ftp.gnu.org/gnu/binutils/binutils-2.43.1.tar.bz2"
-  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.43.1.tar.bz2"
-  sha256 "becaac5d295e037587b63a42fad57fe3d9d7b83f478eb24b67f9eec5d0f1872f"
+  url "https://ftp.gnu.org/gnu/binutils/binutils-2.44.tar.bz2"
+  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.44.tar.bz2"
+  sha256 "f66390a661faa117d00fab2e79cf2dc9d097b42cc296bf3f8677d1e7b452dc3a"
+
   license all_of: ["GPL-2.0-or-later", "GPL-3.0-or-later", "LGPL-2.0-or-later", "LGPL-3.0-only"]
 
-  bottle do
-    root_url "https://github.com/osx-cross/homebrew-avr/releases/download/avr-binutils-2.43.1"
-    sha256 arm64_sequoia: "2d743962b338269f170aabf4ae2e65a0d49328ad94bccfabb8a00be26837a061"
-    sha256 arm64_sonoma:  "468910d458b982e5a8e20c8401cb6c19e7128ae645042b1b6fbc9d16bbdfda66"
-    sha256 ventura:       "aed052952cc2b4413b8b54aed25eaaa3997c7ea2be002931c278efff9061ae15"
-  end
+  head "https://sourceware.org/git/binutils-gdb.git", branch: "master"
 
   uses_from_macos "zlib"
 
@@ -65,7 +61,7 @@ class AvrBinutils < Formula
   end
 
   test do
-    version_output = "GNU ld (GNU Binutils) 2.43.1\n"
+    version_output = "GNU ld (GNU Binutils) 2.44\n"
     assert_equal `avr-ld -v`, version_output
   end
 end

--- a/Formula/avr-binutils.rb
+++ b/Formula/avr-binutils.rb
@@ -37,19 +37,21 @@ class AvrBinutils < Formula
   end
 
   def install
-    args = [
-      "--prefix=#{prefix}",
-      "--libdir=#{lib}/avr",
-      "--infodir=#{info}",
-      "--mandir=#{man}",
+    args = %W[
+      --prefix=#{prefix}
+      --libdir=#{lib}/avr
+      --infodir=#{info}
+      --mandir=#{man}
 
-      "--target=avr",
+      --target=avr
 
-      "--disable-nls",
-      "--disable-debug",
-      "--disable-werror",
-      "--disable-dependency-tracking",
-      "--enable-deterministic-archives",
+      --disable-nls
+      --disable-debug
+      --disable-werror
+      --disable-dependency-tracking
+      --enable-deterministic-archives
+
+      --with-system-zlib
     ]
 
     mkdir "build" do

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ AVR is a popular family of micro-controllers, used for example in the [Arduino] 
 - GCC 12.2.0 - provided as `avr-gcc@12`
 - GCC 13.3.0 - provided as `avr-gcc@13`
 - GCC 14.2.0 - provided as `avr-gcc@14`
-- Binutils 2.43.1 - provided as `avr-binutils`
+- Binutils 2.44 - provided as `avr-binutils`
 - AVR Libc 2.2.1 - provided as a resource for each GCC formula
 - GDB 15.2 - provided as `avr-gdb`
 


### PR DESCRIPTION
This updates the sources for the `avr-binutils` formula to Binutils 2.44.

Also, this fixes a compilation error on newer versions of macOS Sequoia by using the system `zlib`, which was already included by the formula anyways.
<details>
<summary>Compilation error</summary>

```
[...]
In file included from ../../zlib/zutil.c:10:
In file included from ../../zlib/gzguts.h:21:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/stdio.h:61:
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/_stdio.h:318:7: error: expected identifier or '('
  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
      |          ^
../../zlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/__stddef_null.h:26:16: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                ^
In file included from ../../zlib/zutil.c:10:
In file included from ../../zlib/gzguts.h:21:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/stdio.h:61:
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/_stdio.h:318:7: error: expected ')'
../../zlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/__stddef_null.h:26:16: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/_stdio.h:318:7: note: to match this '('
../../zlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/__stddef_null.h:26:15: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |               ^
In file included from ../../zlib/zutil.c:10:
In file included from ../../zlib/gzguts.h:21:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/stdio.h:61:
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/_stdio.h:318:7: error: expected ')'
  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
      |          ^
../../zlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/__stddef_null.h:26:22: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/_stdio.h:318:7: note: to match this '('
../../zlib/zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/17/include/__stddef_null.h:26:14: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |              ^
[...]
```
</details>

Furthermore, the README is updated for the new version of the formula.

The Homebrew checks `brew test ./Formula/avr-binutils.rb`, `brew audit --strict --online avr-binutils` and `brew style --fix ./Formula/avr-binutils.rb` pass. Basic testing was performed as part of an avr-gcc toolchain by compiling, linking and running a few different programs. This was done on macOS Sequoia 15.4.1 on AArch64 with Xcode 16.3.