### PR TITLE
Upgrade avr-gdb to 16.3

### DIFF
--- a/Formula/avr-gdb.rb
+++ b/Formula/avr-gdb.rb
@@ -1,21 +1,17 @@
 class AvrGdb < Formula
   desc "GNU debugger for AVR 8-bit and 32-bit Microcontrollers"
   homepage "https://www.gnu.org/software/gdb/"
-  url "https://ftp.gnu.org/gnu/gdb/gdb-15.2.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gdb/gdb-15.2.tar.xz"
-  sha256 "83350ccd35b5b5a0cba6b334c41294ea968158c573940904f00b92f76345314d"
+
+  url "https://ftp.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
+  mirror "https://ftpmirror.gnu.org/gdb/gdb-16.3.tar.xz"
+  sha256 "bcfcd095528a987917acf9fff3f1672181694926cc18d609c99d0042c00224c5"
+
   license "GPL-3.0-or-later"
+
   head "https://sourceware.org/git/binutils-gdb.git", branch: "master"
 
   livecheck do
     formula "gdb"
-  end
-
-  bottle do
-    root_url "https://github.com/osx-cross/homebrew-avr/releases/download/avr-gdb-15.2"
-    sha256 arm64_sequoia: "f661344b26bafca4db032882591009eb86274f1742718d5678313dbae94f6f97"
-    sha256 arm64_sonoma:  "8b745f7a3747f276f7544479a045a018664db06e371b1ed537e1d14fa51fd9b8"
-    sha256 ventura:       "290d51abfc06bb33ada39560f737b659bc387c76cfc4d3ca25b789780034f74a"
   end
 
   depends_on "avr-gcc@14" => :test

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ AVR is a popular family of micro-controllers, used for example in the [Arduino] 
 - GCC 14.2.0 - provided as `avr-gcc@14`
 - Binutils 2.44 - provided as `avr-binutils`
 - AVR Libc 2.2.1 - provided as a resource for each GCC formula
-- GDB 15.2 - provided as `avr-gdb`
+- GDB 16.3 - provided as `avr-gdb`
 
 Support for older GCC versions (4, 5, 6, 7) has been removed. Please, raise an issue if you need one back.
 


### PR DESCRIPTION
This updates the sources for the `avr-gdb` formula to GDB 16.3.

Also, the README is updated to reflect the new version of the formula.

The following Homebrew checks have been run and pass: `brew test ./Formula/avr-gdb.rb`, `brew audit --strict --online avr-gdb` and `brew style --fix ./Formula/avr-gdb.rb`.

Basic debugging tests were done with QEMU (9.2.2) on macOS Sequoia 15.4.1 on AArch64 with Xcode 16.3.