### PR TITLE
Add avr-gcc@15 formula

### DIFF
--- a/Formula/avr-gcc@15.rb
+++ b/Formula/avr-gcc@15.rb
@@ -1,0 +1,155 @@
+class AvrGccAT15 < Formula
+  desc "GNU compiler collection for AVR 8-bit and 32-bit Microcontrollers"
+  homepage "https://gcc.gnu.org/"
+
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-15.2.0/gcc-15.2.0.tar.xz"
+  sha256 "438fd996826b0c82485a29da03a72d71d6e3541a83ec702df4271f6fe025d24e"
+
+  license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
+
+  head "https://gcc.gnu.org/git/gcc.git", branch: "master"
+
+  # The bottles are built on systems with the CLT installed, and do not work
+  # out of the box on Xcode-only systems due to an incorrect sysroot.
+  pour_bottle? only_if: :clt_installed
+
+  keg_only "it might interfere with other version of avr-gcc.\n" \
+           "This is useful if you want to have multiple version of avr-gcc\n" \
+           "installed on the same machine"
+
+  depends_on "avr-binutils"
+
+  depends_on "gmp"
+  depends_on "isl"
+  depends_on "libmpc"
+  depends_on "mpfr"
+  depends_on "zstd"
+
+  uses_from_macos "zlib"
+
+  resource "avr-libc" do
+    url "https://github.com/avrdudes/avr-libc/releases/download/avr-libc-2_2_1-release/avr-libc-2.2.1.tar.bz2"
+    sha256 "006a6306cbbc938c3bdb583ac54f93fe7d7c8cf97f9cde91f91c6fb0273ab465"
+  end
+
+  # Branch from the Darwin maintainer of GCC, with a few generic fixes and
+  # Apple Silicon support, located at https://github.com/iains/gcc-15-branch
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/gcc/gcc-15.1.0.diff"
+    sha256 "360fba75cd3ab840c2cd3b04207f745c418df44502298ab156db81d41edf3594"
+  end
+
+  def version_suffix
+    if build.head?
+      "HEAD"
+    else
+      version.major.to_s
+    end
+  end
+
+  def install
+    # GCC will suffer build errors if forced to use a particular linker.
+    ENV.delete "LD"
+
+    # Even when suffixes are appended, the info pages conflict when
+    # install-info is run so pretend we have an outdated makeinfo
+    # to prevent their build.
+    ENV["gcc_cv_prog_makeinfo_modern"] = "no"
+
+    languages = ["c", "c++"]
+
+    pkgversion = "Homebrew AVR GCC #{pkg_version} #{build.used_options*" "}".strip
+
+    args = %W[
+      --target=avr
+      --prefix=#{prefix}
+      --libdir=#{lib}/avr-gcc/#{version_suffix}
+
+      --enable-languages=#{languages.join(",")}
+
+      --with-ld=#{Formula["avr-binutils"].opt_bin/"avr-ld"}
+      --with-as=#{Formula["avr-binutils"].opt_bin/"avr-as"}
+
+      --disable-nls
+      --disable-libssp
+      --disable-shared
+      --disable-threads
+      --disable-libgomp
+
+      --with-dwarf2
+      --with-avrlibc
+
+      --with-system-zlib
+
+      --with-pkgversion=#{pkgversion}
+      --with-bugurl=https://github.com/osx-cross/homebrew-avr/issues
+    ]
+
+    # Avoid reference to sed shim
+    args << "SED=/usr/bin/sed"
+
+    mkdir "build" do
+      system "../configure", *args
+
+      # Use -headerpad_max_install_names in the build,
+      # otherwise updated load commands won't fit in the Mach-O header.
+      # This is needed because `gcc` avoids the superenv shim.
+      system "make", "BOOT_LDFLAGS=-Wl,-headerpad_max_install_names"
+
+      system "make", "install"
+    end
+
+    # info and man7 files conflict with native gcc
+    rm_r(info)
+    rm_r(man7)
+
+    resource("avr-libc").stage do
+      ENV.prepend_path "PATH", bin
+
+      ENV.delete "CFLAGS"
+      ENV.delete "CXXFLAGS"
+      ENV.delete "LD"
+      ENV.delete "CC"
+      ENV.delete "CXX"
+
+      system "./configure", "--prefix=#{prefix}", "--host=avr"
+      system "make", "install"
+    end
+  end
+
+  test do
+    ENV.delete "CPATH"
+
+    hello_c = <<~EOS
+      #define F_CPU 8000000UL
+      #include <avr/io.h>
+      #include <util/delay.h>
+      int main (void) {
+        DDRB |= (1 << PB0);
+        while(1) {
+          PORTB ^= (1 << PB0);
+          _delay_ms(500);
+        }
+        return 0;
+      }
+    EOS
+
+    hello_c_hex = <<~EOS
+      :10000000209A91E085B1892785B92FEF34E38CE000
+      :0E001000215030408040E1F700C00000F3CFE7
+      :00000001FF
+    EOS
+
+    hello_c_hex.gsub!("\n", "\r\n")
+
+    (testpath/"hello.c").write(hello_c)
+
+    system "#{bin}/avr-gcc", "-mmcu=atmega328p", "-Os", "-c", "hello.c", "-o", "hello.c.o", "--verbose"
+    system "#{bin}/avr-gcc", "hello.c.o", "-o", "hello.c.elf"
+    system "#{Formula["avr-binutils"].opt_bin}/avr-objcopy", "-O", "ihex", "-j", ".text", "-j", ".data",
+      "hello.c.elf", "hello.c.hex"
+
+    assert_equal `cat hello.c.hex`, hello_c_hex
+  end
+end

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ AVR is a popular family of micro-controllers, used for example in the [Arduino] 
 - GCC 12.2.0 - provided as `avr-gcc@12`
 - GCC 13.3.0 - provided as `avr-gcc@13`
 - GCC 14.2.0 - provided as `avr-gcc@14`
+- GCC 15.2.0 - provided as `avr-gcc@15`
 - Binutils 2.44 - provided as `avr-binutils`
 - AVR Libc 2.2.1 - provided as a resource for each GCC formula
 - GDB 16.3 - provided as `avr-gdb`


### PR DESCRIPTION
This adds a new `avr-gcc@15` formula for GCC 15.1.0. The formula is based on the formula for AVR-GCC 14.2.0 and the [Homebrew Core formula for GCC 15.1.0](https://github.com/Homebrew/homebrew-core/blob/42ab733263ad1e3c9c31a8613f752f995f1b18e4/Formula/g/gcc.rb). The latter also updates the GCC patches to the GCC 15.1.0 branch of the Darwin maintainer of GCC.

The following Homebrew checks have been run successfully: `brew test ./Formula/avr-gcc@15.rb`, `brew audit --strict avr-gcc@15` and `brew style --fix ./Formula/avr-gcc@15.rb`.

This has been tested on macOS 15.5 on AArch64 with Xcode 16.4. Some on-device tests have been done with a ATmega2560.

Furthermore, the README is updated to include the new formula.