### PR TITLE
Swap GNU FTP primary and mirror URLs to resolve style issue

### DIFF
--- a/Formula/avr-binutils.rb
+++ b/Formula/avr-binutils.rb
@@ -2,8 +2,8 @@ class AvrBinutils < Formula
   desc "GNU Binutils for the AVR target"
   homepage "https://www.gnu.org/software/binutils"
 
-  url "https://ftp.gnu.org/gnu/binutils/binutils-2.44.tar.bz2"
-  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.44.tar.bz2"
+  url "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.44.tar.bz2"
+  mirror "https://ftp.gnu.org/binutils/binutils-2.44.tar.bz2"
   sha256 "f66390a661faa117d00fab2e79cf2dc9d097b42cc296bf3f8677d1e7b452dc3a"
 
   license all_of: ["GPL-2.0-or-later", "GPL-3.0-or-later", "LGPL-2.0-or-later", "LGPL-3.0-only"]

--- a/Formula/avr-gcc@10.rb
+++ b/Formula/avr-gcc@10.rb
@@ -2,8 +2,8 @@ class AvrGccAT10 < Formula
   desc "GNU compiler collection for AVR 8-bit and 32-bit Microcontrollers"
   homepage "https://gcc.gnu.org/"
 
-  url "https://ftp.gnu.org/gnu/gcc/gcc-10.3.0/gcc-10.3.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-10.3.0/gcc-10.3.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-10.3.0/gcc-10.3.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-10.3.0/gcc-10.3.0.tar.xz"
   sha256 "64f404c1a650f27fc33da242e1f2df54952e3963a49e06e73f6940f3223ac344"
 
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }

--- a/Formula/avr-gcc@11.rb
+++ b/Formula/avr-gcc@11.rb
@@ -2,8 +2,8 @@ class AvrGccAT11 < Formula
   desc "GNU compiler collection for AVR 8-bit and 32-bit Microcontrollers"
   homepage "https://gcc.gnu.org/"
 
-  url "https://ftp.gnu.org/gnu/gcc/gcc-11.3.0/gcc-11.3.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-11.3.0/gcc-11.3.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-11.3.0/gcc-11.3.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-11.3.0/gcc-11.3.0.tar.xz"
   sha256 "b47cf2818691f5b1e21df2bb38c795fac2cfbd640ede2d0a5e1c89e338a3ac39"
 
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }

--- a/Formula/avr-gcc@12.rb
+++ b/Formula/avr-gcc@12.rb
@@ -2,8 +2,8 @@ class AvrGccAT12 < Formula
   desc "GNU compiler collection for AVR 8-bit and 32-bit Microcontrollers"
   homepage "https://gcc.gnu.org/"
 
-  url "https://ftp.gnu.org/gnu/gcc/gcc-12.2.0/gcc-12.2.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-12.2.0/gcc-12.2.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-12.2.0/gcc-12.2.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-12.2.0/gcc-12.2.0.tar.xz"
   sha256 "e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff"
 
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }

--- a/Formula/avr-gcc@13.rb
+++ b/Formula/avr-gcc@13.rb
@@ -2,8 +2,8 @@ class AvrGccAT13 < Formula
   desc "GNU compiler collection for AVR 8-bit and 32-bit Microcontrollers"
   homepage "https://gcc.gnu.org/"
 
-  url "https://ftp.gnu.org/gnu/gcc/gcc-13.3.0/gcc-13.3.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-13.3.0/gcc-13.3.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-13.3.0/gcc-13.3.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-13.3.0/gcc-13.3.0.tar.xz"
   sha256 "0845e9621c9543a13f484e94584a49ffc0129970e9914624235fc1d061a0c083"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 

--- a/Formula/avr-gcc@14.rb
+++ b/Formula/avr-gcc@14.rb
@@ -2,8 +2,8 @@ class AvrGccAT14 < Formula
   desc "GNU compiler collection for AVR 8-bit and 32-bit Microcontrollers"
   homepage "https://gcc.gnu.org/"
 
-  url "https://ftp.gnu.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz"
   sha256 "a7b39bc69cbf9e25826c5a60ab26477001f7c08d85cec04bc0e29cabed6f3cc9"
 
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }

--- a/Formula/avr-gcc@8.rb
+++ b/Formula/avr-gcc@8.rb
@@ -2,8 +2,8 @@ class AvrGccAT8 < Formula
   desc "GNU compiler collection for AVR 8-bit and 32-bit Microcontrollers"
   homepage "https://www.gnu.org/software/gcc/gcc.html"
 
-  url "https://ftp.gnu.org/gnu/gcc/gcc-8.5.0/gcc-8.5.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-8.5.0/gcc-8.5.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-8.5.0/gcc-8.5.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-8.5.0/gcc-8.5.0.tar.xz"
   sha256 "d308841a511bb830a6100397b0042db24ce11f642dab6ea6ee44842e5325ed50"
 
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }

--- a/Formula/avr-gcc@9.rb
+++ b/Formula/avr-gcc@9.rb
@@ -2,8 +2,8 @@ class AvrGccAT9 < Formula
   desc "GNU compiler collection for AVR 8-bit and 32-bit Microcontrollers"
   homepage "https://gcc.gnu.org/"
 
-  url "https://ftp.gnu.org/gnu/gcc/gcc-9.4.0/gcc-9.4.0.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gcc/gcc-9.4.0/gcc-9.4.0.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gcc/gcc-9.4.0/gcc-9.4.0.tar.xz"
+  mirror "https://ftp.gnu.org/gcc/gcc-9.4.0/gcc-9.4.0.tar.xz"
   sha256 "c95da32f440378d7751dd95533186f7fc05ceb4fb65eb5b85234e6299eb9838e"
 
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }

--- a/Formula/avr-gdb.rb
+++ b/Formula/avr-gdb.rb
@@ -2,8 +2,8 @@ class AvrGdb < Formula
   desc "GNU debugger for AVR 8-bit and 32-bit Microcontrollers"
   homepage "https://www.gnu.org/software/gdb/"
 
-  url "https://ftp.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
-  mirror "https://ftpmirror.gnu.org/gdb/gdb-16.3.tar.xz"
+  url "https://ftpmirror.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
+  mirror "https://ftp.gnu.org/gdb/gdb-16.3.tar.xz"
   sha256 "bcfcd095528a987917acf9fff3f1672181694926cc18d609c99d0042c00224c5"
 
   license "GPL-3.0-or-later"


### PR DESCRIPTION
In Homebrew/brew [`049e8cc`](https://github.com/Homebrew/brew/commit/049e8cc) and [`3f4d19e`](https://github.com/Homebrew/brew/commit/3f4d19e), the URL audit check was changed to prefer `https://ftpmirror.gnu.org` as the primary URL to reduce load on `https://ftp.gnu.org`.

Here, all the primary and mirror URLs of GNU formulas are swapped to resolve the style violations introduced by this check. This should resolve recent failures of the test-bot on the following check: `brew style osx-cross/avr`.

The changes for all formulas are combined into a single commit, as this only affects the formulas itself and should require any rebottling.