### PR TITLE
Update avr-gcc@9 to 9.5.0

### DIFF
--- a/Formula/avr-gcc@9.rb
+++ b/Formula/avr-gcc@9.rb
@@ -2,12 +2,11 @@ class AvrGccAT9 < Formula
   desc "GNU compiler collection for AVR 8-bit and 32-bit Microcontrollers"
   homepage "https://gcc.gnu.org/"
 
-  url "https://ftpmirror.gnu.org/gcc/gcc-9.4.0/gcc-9.4.0.tar.xz"
-  mirror "https://ftp.gnu.org/gnu/gcc/gcc-9.4.0/gcc-9.4.0.tar.xz"
-  sha256 "c95da32f440378d7751dd95533186f7fc05ceb4fb65eb5b85234e6299eb9838e"
+  url "https://ftpmirror.gnu.org/gcc/gcc-9.5.0/gcc-9.5.0.tar.xz"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-9.5.0/gcc-9.5.0.tar.xz"
+  sha256 "27769f64ef1d4cd5e2be8682c0c93f9887983e6cfd1a927ce5a0a2915a95cf8f"
 
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
-  revision 1
 
   head "https://gcc.gnu.org/git/gcc.git", branch: "releases/gcc-9"
 

--- a/Formula/avr-gcc@9.rb
+++ b/Formula/avr-gcc@9.rb
@@ -11,13 +11,6 @@ class AvrGccAT9 < Formula
 
   head "https://gcc.gnu.org/git/gcc.git", branch: "releases/gcc-9"
 
-  bottle do
-    root_url "https://github.com/osx-cross/homebrew-avr/releases/download/avr-gcc@9-9.4.0_1"
-    sha256 arm64_sonoma: "bd400587fee5d1f34c41de95d80a2e0bd99eb350902e1c535c1ae332a5107f00"
-    sha256 ventura:      "d057720b566d688fd97c5c2293fc07090da0e6988c677abe894e132471243589"
-    sha256 monterey:     "74ce93105e38ff9a61383348924d603f18d41cd7440822ec7337ee6aa9609f8f"
-  end
-
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
   pour_bottle? only_if: :clt_installed
@@ -57,6 +50,13 @@ class AvrGccAT9 < Formula
   patch do
     url "https://gist.githubusercontent.com/DavidEGrayson/88bceb3f4e62f45725ecbb9248366300/raw/c1f515475aff1e1e3985569d9b715edb0f317648/gcc-11-arm-darwin.patch"
     sha256 "c4e9df9802772ddecb71aa675bb9403ad34c085d1359cb0e45b308ab6db551c6"
+  end
+
+  # Backport upstream GCC commit to avoid an include poisoning issue in the
+  # libc++ version included in more recent macOS SDKs.
+  patch do
+    url "https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=9970b576b7e4ae337af1268395ff221348c4b34a"
+    sha256 "aa67dbab17af5e8396c05d866bf871ac07c444fe9e684241710ecc6b5de90bfd"
   end
 
   def install

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ AVR is a popular family of micro-controllers, used for example in the [Arduino] 
 
 ## Current Versions
 
-- GCC 9.4.0 - **default**, provided as `avr-gcc` or `avr-gcc@9`
+- GCC 9.5.0 - **default**, provided as `avr-gcc` or `avr-gcc@9`
 - GCC 8.5.0 - provided as `avr-gcc@8`
 - GCC 10.3.0 - provided as `avr-gcc@10`
 - GCC 11.3.0 - provided as `avr-gcc@11`


### PR DESCRIPTION
This updates the GCC sources to 9.5.0. Furthermore, this PR backports upstream GCC commit [9970b57](https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=9970b576b7e4ae337af1268395ff221348c4b34a) to resolve an include poisoning issue when compiling against the libc++ of newer versions of the macOS SDK.

The README is updated with the new version of the formula.

Standard audit and style checks and tests have been run successfully on macOS 15.6 (Aarch64) with Xcode 26.1. This was tested on an ATmega 2560 board.