### PR TITLE
Update avr-gcc@10 to 10.5.0

### DIFF
--- a/Formula/avr-gcc@10.rb
+++ b/Formula/avr-gcc@10.rb
@@ -12,13 +12,6 @@ class AvrGccAT10 < Formula
 
   head "https://gcc.gnu.org/git/gcc.git", branch: "releases/gcc-10"
 
-  bottle do
-    root_url "https://github.com/osx-cross/homebrew-avr/releases/download/avr-gcc@10-10.3.0_3"
-    sha256 arm64_sonoma: "a3389faf9a2ddfb9f2177300f2ac016f845105de60fecdadee1f59392ee4d034"
-    sha256 ventura:      "e84948abf83aaac9733d6ddde8d295e41abdcf42e2bb4c7d5ec66f016c5ecca1"
-    sha256 monterey:     "8d3975f45f96600e3a5fa44c5aafa361d6a9cf87f383ea8abbcc884cb896d7c0"
-  end
-
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
   pour_bottle? only_if: :clt_installed
@@ -62,6 +55,13 @@ class AvrGccAT10 < Formula
   patch do
     url "https://gist.githubusercontent.com/DavidEGrayson/88bceb3f4e62f45725ecbb9248366300/raw/c1f515475aff1e1e3985569d9b715edb0f317648/gcc-11-arm-darwin.patch"
     sha256 "c4e9df9802772ddecb71aa675bb9403ad34c085d1359cb0e45b308ab6db551c6"
+  end
+
+  # Backport upstream GCC commit to avoid an include poisoning issue in the
+  # libc++ version included in more recent macOS SDKs.
+  patch do
+    url "https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=9970b576b7e4ae337af1268395ff221348c4b34a"
+    sha256 "aa67dbab17af5e8396c05d866bf871ac07c444fe9e684241710ecc6b5de90bfd"
   end
 
   def install

--- a/Formula/avr-gcc@10.rb
+++ b/Formula/avr-gcc@10.rb
@@ -2,13 +2,11 @@ class AvrGccAT10 < Formula
   desc "GNU compiler collection for AVR 8-bit and 32-bit Microcontrollers"
   homepage "https://gcc.gnu.org/"
 
-  url "https://ftpmirror.gnu.org/gcc/gcc-10.3.0/gcc-10.3.0.tar.xz"
-  mirror "https://ftp.gnu.org/gnu/gcc/gcc-10.3.0/gcc-10.3.0.tar.xz"
-  sha256 "64f404c1a650f27fc33da242e1f2df54952e3963a49e06e73f6940f3223ac344"
+  url "https://ftpmirror.gnu.org/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-10.5.0/gcc-10.5.0.tar.xz"
+  sha256 "25109543fdf46f397c347b5d8b7a2c7e5694a5a51cce4b9c6e1ea8a71ca307c1"
 
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
-
-  revision 3
 
   head "https://gcc.gnu.org/git/gcc.git", branch: "releases/gcc-10"
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AVR is a popular family of micro-controllers, used for example in the [Arduino] 
 
 - GCC 9.5.0 - **default**, provided as `avr-gcc` or `avr-gcc@9`
 - GCC 8.5.0 - provided as `avr-gcc@8`
-- GCC 10.3.0 - provided as `avr-gcc@10`
+- GCC 10.5.0 - provided as `avr-gcc@10`
 - GCC 11.5.0 - provided as `avr-gcc@11`
 - GCC 12.2.0 - provided as `avr-gcc@12`
 - GCC 13.4.0 - provided as `avr-gcc@13`


### PR DESCRIPTION
This updates the GCC sources to 10.5.0. Furthermore, this PR backports upstream GCC commit [9970b57](https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=9970b576b7e4ae337af1268395ff221348c4b34a) to resolve an include poisoning issue when compiling against the libc++ of newer versions of the macOS SDK.

The README is updated with the new version of the formula.

Standard audit and style checks and tests have been run successfully on macOS 15.6 (Aarch64) with Xcode 26.1. This was tested on an ATmega 2560 board.