### PR TITLE
Update avr-gdb to 17.2

### DIFF
--- a/Formula/avr-gdb.rb
+++ b/Formula/avr-gdb.rb
@@ -1,38 +1,41 @@
 class AvrGdb < Formula
   desc "GNU debugger for AVR 8-bit and 32-bit Microcontrollers"
   homepage "https://www.gnu.org/software/gdb/"
-
-  url "https://ftpmirror.gnu.org/gdb/gdb-16.3.tar.xz"
-  mirror "https://ftp.gnu.org/gnu/gdb/gdb-16.3.tar.xz"
-  sha256 "bcfcd095528a987917acf9fff3f1672181694926cc18d609c99d0042c00224c5"
-
+  url "https://ftpmirror.gnu.org/gnu/gdb/gdb-17.2.tar.xz"
+  mirror "https://ftp.gnu.org/gnu/gdb/gdb-17.2.tar.xz"
+  sha256 "1c036c0d72e4b3d1fb5c94c88632add6f9d76f4d7c4d2ea793c12a9f19a3228c"
   license "GPL-3.0-or-later"
-
   head "https://sourceware.org/git/binutils-gdb.git", branch: "master"
 
   livecheck do
     formula "gdb"
   end
 
-  bottle do
-    root_url "https://github.com/osx-cross/homebrew-avr/releases/download/avr-gdb-16.3"
-    sha256 arm64_sequoia: "f5eeb26b1dadd9f23db311aba4d85588da92f15ed61274b6aadcd5e2e7ae02cf"
-    sha256 arm64_sonoma:  "61eb2b3d243f2d6487f2262bd6f4506aa42a8a4571752cf1e460989464a39e76"
-    sha256 ventura:       "ca966c101bdd29ba82ce410b768b2a367812b52b8d5800a44571b4388e54b241"
-  end
-
-  depends_on "avr-gcc@14" => :test
+  depends_on "pkgconf" => :build
+  depends_on "avr-gcc@15" => :test
   depends_on "gmp"
   depends_on "mpfr"
-  depends_on "python@3.12"
+  depends_on "ncurses" # https://github.com/Homebrew/homebrew-core/issues/224294
+  depends_on "python@3.14"
+  depends_on "readline"
   depends_on "xz" # required for lzma support
+  depends_on "zstd"
 
-  uses_from_macos "expat"
-  uses_from_macos "ncurses"
-  uses_from_macos "zlib"
+  uses_from_macos "expat", since: :sequoia # minimum macOS due to python
+
+  # Workaround for https://github.com/Homebrew/brew/issues/19315
+  on_sequoia :or_newer do
+    on_intel do
+      depends_on "expat"
+    end
+  end
 
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build
+  end
+
+  on_linux do
+    depends_on "zlib-ng-compat"
   end
 
   def install
@@ -43,10 +46,16 @@ class AvrGdb < Formula
       --includedir=#{include}/#{target}
       --infodir=#{info}/#{target}
       --mandir=#{man}
-      --with-lzma
-      --with-python=#{Formula["python@3.12"].opt_bin}/python3.12
-      --with-system-zlib
       --disable-binutils
+      --disable-nls
+      --enable-tui
+      --with-curses
+      --with-expat
+      --with-lzma
+      --with-python=#{which("python3.14")}
+      --with-system-readline
+      --with-system-zlib
+      --with-zstd
     ]
 
     mkdir "build" do
@@ -61,9 +70,8 @@ class AvrGdb < Formula
 
   test do
     (testpath/"test.c").write "void _start(void) {}"
-    system "#{Formula["avr-gcc@14"].bin}/avr-gcc", "-g", "-nostdlib", "test.c"
-
-    output = shell_output("#{bin}/avr-gdb -batch -ex 'info address _start' a.out")
-    assert_match "Symbol \"_start\" is a function at address 0x", output
+    system Formula["avr-gcc@15"].bin/"avr-gcc", "-g", "-nostdlib", "test.c"
+    assert_match "Symbol \"_start\" is a function at address 0x",
+          shell_output("#{bin}/avr-gdb -batch -ex 'info address _start' a.out")
   end
 end

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ AVR is a popular family of micro-controllers, used for example in the [Arduino] 
 - GCC 15.2.0 - provided as `avr-gcc@15`
 - Binutils 2.44 - provided as `avr-binutils`
 - AVR Libc 2.2.1 - provided as a resource for each GCC formula
-- GDB 16.3 - provided as `avr-gdb`
+- GDB 17.2 - provided as `avr-gdb`
 
 Support for older GCC versions (4, 5, 6, 7) has been removed. Please, raise an issue if you need one back.
 


### PR DESCRIPTION
This updates the GDB sources to 17.2 and adjusts the formula to be more in line with current versions of the Homebrew Core formulas for [aarch64-elf-gdb](https://github.com/Homebrew/homebrew-core/blob/8a576e8174ca2b6628fca3cf3245a9b0fdfccc6c/Formula/a/aarch64-elf-gdb.rb) and [riscv64-elf-gdb](https://github.com/Homebrew/homebrew-core/blob/f31aaa667fc1ce1a02e29051c97f46c5b46ebb45/Formula/r/riscv64-elf-gdb.rb). Among others, this updates the Python dependency to 3.14 and adds zstd support. Also, the dependency on avr-gcc for testing is updated to avr-gcc@15.

The README is updated with the new version of the formula.

All standard tests and audit and style checks been run on macOS 26.4.1 (Aarch64) with Xcode 26.5. This was tested with an ATmega 2560 board via JTAG (Atmel ICE) and AVaRICE.