### PR TITLE
Update avr-gcc@12 to 12.5.0

### DIFF
--- a/Formula/avr-gcc@12.rb
+++ b/Formula/avr-gcc@12.rb
@@ -2,20 +2,13 @@ class AvrGccAT12 < Formula
   desc "GNU compiler collection for AVR 8-bit and 32-bit Microcontrollers"
   homepage "https://gcc.gnu.org/"
 
-  url "https://ftpmirror.gnu.org/gcc/gcc-12.4.0/gcc-12.4.0.tar.xz"
-  mirror "https://ftp.gnu.org/gnu/gcc/gcc-12.4.0/gcc-12.4.0.tar.xz"
-  sha256 "704f652604ccbccb14bdabf3478c9511c89788b12cb3bbffded37341916a9175"
+  url "https://ftpmirror.gnu.org/gcc/gcc-12.5.0/gcc-12.5.0.tar.xz"
+  mirror "https://ftp.gnu.org/gnu/gcc/gcc-12.5.0/gcc-12.5.0.tar.xz"
+  sha256 "71cd373d0f04615e66c5b5b14d49c1a4c1a08efa7b30625cd240b11bab4062b3"
 
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 
   head "https://gcc.gnu.org/git/gcc.git", branch: "master"
-
-  bottle do
-    root_url "https://github.com/osx-cross/homebrew-avr/releases/download/avr-gcc@12-12.4.0"
-    sha256 arm64_tahoe:   "94ee6f4dc2eeffd65ac9f44042815d47bf766ff594a6cf73723eb03d35e77c61"
-    sha256 arm64_sequoia: "4932939cbf20226887cbdbb6ae30cbb6477b146b9a5025d260b9e12fa5104a0e"
-    sha256 arm64_sonoma:  "59784dc8ff002a8f4fd7d94ff247039d2d82161000d6022b987fb8bd8eec5362"
-  end
 
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
@@ -35,6 +28,7 @@ class AvrGccAT12 < Formula
   depends_on "libmpc"
   depends_on "mpfr"
   depends_on "osx-cross/avr/avr-binutils"
+  depends_on "zstd"
 
   uses_from_macos "zlib"
 
@@ -48,16 +42,22 @@ class AvrGccAT12 < Formula
   # Branch from the Darwin maintainer of GCC, with a few generic fixes and
   # Apple Silicon support, located at https://github.com/iains/gcc-12-branch
   patch do
-    url "https://raw.githubusercontent.com/Homebrew/homebrew-core/1cf441a0/Patches/gcc/gcc-12.4.0.diff"
-    sha256 "c0e8e94fbf65a6ce13286e7f13beb5a1d84b182a610489026ce3e2420fc3d45c"
+    url "https://raw.githubusercontent.com/Homebrew/homebrew-core/8ce16876/Patches/gcc/gcc-12.4.0.diff"
+    sha256 "6178f6473bd2c225ed80745834d584e1c3beff9597f5afa982f249efb39ca084"
   end
 
   # Backport commits to build on Sonoma/Sequoia to allow rebottling.
-  # TODO: merge into above patch when updating to 12.5.0.
+  # TODO: create merged patch if https://github.com/iains/gcc-12-branch is synced to 12.5.0
   patch do
     on_macos do
-      url "https://github.com/iains/gcc-12-branch/compare/e300c1337a48cf772b09e7136601fd7f9f09d6f1..99533d94172ed7a24c0e54c4ea97e6ae2260409e.patch"
-      sha256 "f01bf173c1980cef680e407a5cc4f34af13a3e54cd644138735ec35adc5c6e40"
+      url "https://github.com/iains/gcc-12-branch/compare/e300c1337a48cf772b09e7136601fd7f9f09d6f1..914cec39148b1c8a697976275629aa8526ea1050.patch"
+      sha256 "f622b8fb9d36d679bed2c98adc47c46029d40923646410704eb8e04cd672de96"
+    end
+  end
+  patch do
+    on_macos do
+      url "https://github.com/iains/gcc-12-branch/compare/f0f9d56ffca2da2cab9af21c0c378ffe4d9cf908...99533d94172ed7a24c0e54c4ea97e6ae2260409e.patch"
+      sha256 "7aa45104e32a4fd288a8f3b931848dc5c306d0b295ca28c8bf60a048edd8d2a5"
     end
   end
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AVR is a popular family of micro-controllers, used for example in the [Arduino] 
 - GCC 8.5.0 - provided as `avr-gcc@8`
 - GCC 10.5.0 - provided as `avr-gcc@10`
 - GCC 11.5.0 - provided as `avr-gcc@11`
-- GCC 12.2.0 - provided as `avr-gcc@12`
+- GCC 12.5.0 - provided as `avr-gcc@12`
 - GCC 13.4.0 - provided as `avr-gcc@13`
 - GCC 14.3.0 - provided as `avr-gcc@14`
 - GCC 15.2.0 - provided as `avr-gcc@15`


### PR DESCRIPTION
This updates the GCC sources to 12.5.0. As there has not been a release of the patches by the Darwin GCC maintainer for this version yet, this updates the patches to the latest 12.4.0 version and includes a few commits from the maintainer's repo. This is also what was done for the Homebrew Core [gcc@12 formula](https://github.com/Homebrew/homebrew-core/blob/2258ab475faf0cca18cdd258b8f40dc1d199072f/Formula/g/gcc%4012.rb).

The README is updated with the new version of the formula.

The standard audit and style checks and tests have been run successfully on macOS 26.5 (Aarch64) with Xcode 26.5. Rudimentary testing was done with an ATmega 2560 board.